### PR TITLE
:arrow_down: downgrade GraphQL packages

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
     flutter:
         sdk: flutter
 
-    ferry: ^0.15.0
-    ferry_flutter: ^0.9.0
+    ferry: ^0.14.2+1
+    ferry_flutter: ^0.8.1
     gql_http_link: ^1.0.1
     gql_websocket_link: ^1.1.0
     web_socket_channel: ^2.4.0
@@ -26,7 +26,7 @@ dev_dependencies:
         sdk: flutter
     flutter_lints: ^3.0.0
 
-    ferry_generator: ^0.9.0-dev.0+1
+    ferry_generator: ^0.8.1
     build_runner: ^2.4.6
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
The parameter page is using `graphql_flutter` which has dependencies that aren't compatible with the latest `ferry` dependencies.