### PR TITLE
:arrow_up: bump version of `go_router` and `gql_websocket_link`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,13 +14,13 @@ dependencies:
     ferry: ^0.14.2+1
     ferry_flutter: ^0.8.1
     gql_http_link: ^1.0.1
-    gql_websocket_link: ^1.1.0
+    gql_websocket_link: ^2.0.0
     gql_code_builder: ^0.8.0
     web_socket_channel: ^2.4.0
 
     built_collection: ^5.1.1
     built_value: ^8.4.4
-    go_router: ^10.1.2
+    go_router: ^12.1.0
 
 dev_dependencies:
     flutter_test:


### PR DESCRIPTION
Pull in latest versions of these packages.