### PR TITLE
Make knobbing info optional

### DIFF
--- a/lib/service/acsys/service.dart
+++ b/lib/service/acsys/service.dart
@@ -181,7 +181,7 @@ class DeviceInfo {
   final String name;
   final String description;
   final DeviceInfoProperty? reading;
-  final (DeviceInfoProperty, KnobbingInfo)? setting;
+  final (DeviceInfoProperty, KnobbingInfo?)? setting;
   final DeviceInfoAnalogAlarm? alarm;
   final DeviceInfoBasicStatus? basicStatus;
   final List<DeviceInfoDigitalControl> digControl;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.1.7
+version: 0.1.8
 homepage:
 
 environment:


### PR DESCRIPTION
Not all devices can be knobbed. This changes the field type so the knobbing info is optional. It currently is getting filled, but work in the GraphQL layer will make it conditional.