### PR TITLE
Fix `startPlot` subscription

### DIFF
--- a/lib/src/service/acsys/schema/__generated__/start_plot.ast.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.ast.gql.dart
@@ -47,6 +47,15 @@ const StartPlot = _i1.OperationDefinitionNode(
       defaultValue: _i1.DefaultValueNode(value: null),
       directives: [],
     ),
+    _i1.VariableDefinitionNode(
+      variable: _i1.VariableNode(name: _i1.NameNode(value: 'updateDelay')),
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Int'),
+        isNonNull: false,
+      ),
+      defaultValue: _i1.DefaultValueNode(value: null),
+      directives: [],
+    ),
   ],
   directives: [],
   selectionSet: _i1.SelectionSetNode(selections: [
@@ -69,6 +78,10 @@ const StartPlot = _i1.OperationDefinitionNode(
         _i1.ArgumentNode(
           name: _i1.NameNode(value: 'windowSize'),
           value: _i1.VariableNode(name: _i1.NameNode(value: 'windowSize')),
+        ),
+        _i1.ArgumentNode(
+          name: _i1.NameNode(value: 'updateDelay'),
+          value: _i1.VariableNode(name: _i1.NameNode(value: 'updateDelay')),
         ),
       ],
       directives: [],

--- a/lib/src/service/acsys/schema/__generated__/start_plot.var.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.var.gql.dart
@@ -21,6 +21,7 @@ abstract class GStartPlotVars
   int? get xMin;
   int? get xMax;
   int? get windowSize;
+  int? get updateDelay;
   static Serializer<GStartPlotVars> get serializer =>
       _$gStartPlotVarsSerializer;
 

--- a/lib/src/service/acsys/schema/__generated__/start_plot.var.gql.g.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.var.gql.g.dart
@@ -44,6 +44,12 @@ class _$GStartPlotVarsSerializer
         ..add('windowSize')
         ..add(serializers.serialize(value, specifiedType: const FullType(int)));
     }
+    value = object.updateDelay;
+    if (value != null) {
+      result
+        ..add('updateDelay')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     return result;
   }
 
@@ -77,6 +83,10 @@ class _$GStartPlotVarsSerializer
           result.windowSize = serializers.deserialize(value,
               specifiedType: const FullType(int)) as int?;
           break;
+        case 'updateDelay':
+          result.updateDelay = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
       }
     }
 
@@ -93,12 +103,18 @@ class _$GStartPlotVars extends GStartPlotVars {
   final int? xMax;
   @override
   final int? windowSize;
+  @override
+  final int? updateDelay;
 
   factory _$GStartPlotVars([void Function(GStartPlotVarsBuilder)? updates]) =>
       (new GStartPlotVarsBuilder()..update(updates))._build();
 
   _$GStartPlotVars._(
-      {required this.drfList, this.xMin, this.xMax, this.windowSize})
+      {required this.drfList,
+      this.xMin,
+      this.xMax,
+      this.windowSize,
+      this.updateDelay})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         drfList, r'GStartPlotVars', 'drfList');
@@ -119,7 +135,8 @@ class _$GStartPlotVars extends GStartPlotVars {
         drfList == other.drfList &&
         xMin == other.xMin &&
         xMax == other.xMax &&
-        windowSize == other.windowSize;
+        windowSize == other.windowSize &&
+        updateDelay == other.updateDelay;
   }
 
   @override
@@ -129,6 +146,7 @@ class _$GStartPlotVars extends GStartPlotVars {
     _$hash = $jc(_$hash, xMin.hashCode);
     _$hash = $jc(_$hash, xMax.hashCode);
     _$hash = $jc(_$hash, windowSize.hashCode);
+    _$hash = $jc(_$hash, updateDelay.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -139,7 +157,8 @@ class _$GStartPlotVars extends GStartPlotVars {
           ..add('drfList', drfList)
           ..add('xMin', xMin)
           ..add('xMax', xMax)
-          ..add('windowSize', windowSize))
+          ..add('windowSize', windowSize)
+          ..add('updateDelay', updateDelay))
         .toString();
   }
 }
@@ -165,6 +184,10 @@ class GStartPlotVarsBuilder
   int? get windowSize => _$this._windowSize;
   set windowSize(int? windowSize) => _$this._windowSize = windowSize;
 
+  int? _updateDelay;
+  int? get updateDelay => _$this._updateDelay;
+  set updateDelay(int? updateDelay) => _$this._updateDelay = updateDelay;
+
   GStartPlotVarsBuilder();
 
   GStartPlotVarsBuilder get _$this {
@@ -174,6 +197,7 @@ class GStartPlotVarsBuilder
       _xMin = $v.xMin;
       _xMax = $v.xMax;
       _windowSize = $v.windowSize;
+      _updateDelay = $v.updateDelay;
       _$v = null;
     }
     return this;
@@ -201,7 +225,8 @@ class GStartPlotVarsBuilder
               drfList: drfList.build(),
               xMin: xMin,
               xMax: xMax,
-              windowSize: windowSize);
+              windowSize: windowSize,
+              updateDelay: updateDelay);
     } catch (_) {
       late String _$failedField;
       try {

--- a/lib/src/service/acsys/schema/start_plot.graphql
+++ b/lib/src/service/acsys/schema/start_plot.graphql
@@ -1,5 +1,5 @@
-subscription StartPlot($drfList: [String!]!, $xMin: Int, $xMax: Int, $windowSize: Int) {
-  startPlot(drfList: $drfList, xMin: $xMin, xMax: $xMax, windowSize: $windowSize) {
+subscription StartPlot($drfList: [String!]!, $xMin: Int, $xMax: Int, $windowSize: Int, $updateDelay: Int) {
+  startPlot(drfList: $drfList, xMin: $xMin, xMax: $xMax, windowSize: $windowSize, updateDelay: $updateDelay) {
     plotId
     data {
       channelUnits

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -667,7 +667,9 @@ class ACSysService implements ACSysServiceAPI {
   // be sent for a device in error.
   @override
   Stream<Reading> monitorDevices(List<String> drfs) {
-    final req = GStreamDataReq((b) => b..vars.drfs = ListBuilder(drfs));
+    final req = GStreamDataReq((b) => b
+      ..vars.drfs = ListBuilder(drfs)
+      ..fetchPolicy = FetchPolicy.NetworkOnly);
 
     return _s
         .request(req)
@@ -824,6 +826,7 @@ class ACSysService implements ACSysServiceAPI {
   Stream<PlotReply> startPlot(List<String> drfs,
       {int? xMin, int? xMax, int? windowSize, int? updateRate}) {
     final req = GStartPlotReq((b) => b
+      ..fetchPolicy = FetchPolicy.NetworkOnly
       ..vars.drfList = ListBuilder(drfs)
       ..vars.xMin = xMin
       ..vars.xMax = xMax

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.2.4
+version: 0.2.5
 
 environment:
     sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
This pull request fixes two subscription issues:

- The fetch policies now force network use and ignore the cache.
- The `updateDelay` parameter wasn't getting sent to the service.