### PR TITLE
:bug: fix abstract API

### DIFF
--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -449,7 +449,7 @@ abstract interface class ACSysServiceAPI {
       int? triggerEvent});
 
   /// Saves the plot configuration to the database.
-  Future<void> savePlotConfiguration(
+  Future<PlotConfigurationSnapshot> savePlotConfiguration(
       {required PlotConfigurationSnapshot snapshot});
 
   /// Queries the database for a plot configuration.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.2.6
+version: 0.2.7
 
 environment:
     sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
The abstract API had `Future<void>` for the return type when updating the plot config. It should be a `Future<PlotConfigurationSnapshot>`.