### PR TITLE
:bug: didn't transfer every plot config field

### DIFF
--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1033,12 +1033,9 @@ final class ACSysService implements ACSysServiceAPI {
                 yMax: e.yMax,
                 xMin: e.xMin,
                 xMax: e.xMax,
-
-                // TODO replace with real values from API. 
-                timeDelta: null,
-                isOneShot: false,
-                isScalar: false,
-
+                timeDelta: e.timeDelta,
+                isOneShot: e.isOneShot,
+                isScalar: e.isScalar,
                 isShowLabels: e.isShowLabels,
                 updateDelay: e.updateDelay,
                 nAcquisitions: e.nAcquisitions,
@@ -1072,6 +1069,9 @@ final class ACSysService implements ACSysServiceAPI {
         ..yMax = cfg.yMax
         ..xMin = cfg.xMin
         ..xMax = cfg.xMax
+        ..timeDelta = cfg.timeDelta
+        ..isOneShot = cfg.isOneShot
+        ..isScalar = cfg.isScalar
         ..isShowLabels = cfg.isShowLabels
         ..updateDelay = cfg.updateDelay
         ..nAcquisitions = cfg.nAcquisitions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.2.10
+version: 0.2.11
 
 environment:
     sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
I missed transferring a few of the new fields over to the Dart classes. It resulted in runtime exceptions when trying to build the GraphQL request.