### PR TITLE
Pull request

### DIFF
--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -541,7 +541,7 @@ abstract interface class ACSysServiceAPI {
 /// from the control system. But a better way is to use the [ACSysProvider]
 /// widget which manages an object of this class.
 
-final class ACSysService implements ACSysServiceAPI {
+final class _ACSysService implements ACSysServiceAPI {
   final Client _q;
   final Client _s;
   final Client _qDevDb;
@@ -552,7 +552,7 @@ final class ACSysService implements ACSysServiceAPI {
   // Constructor. This creates the HTTP links needed to communicate with our
   // GraphQL endpoints.
 
-  ACSysService({String? jwt})
+  _ACSysService({String? jwt})
     : _q = Client(
         link: HttpLink(
           "https://acsys-proxy.fnal.gov:8001/acsys",
@@ -1319,28 +1319,39 @@ final class ACSysProvider extends StatelessWidget {
   final Widget child;
   final ACSysServiceAPI? service;
 
+  /// A factory function that creates a [ACSysProvider] widget.
+  ///
+  /// This function returns a function that can be added to the list passed to
+  /// the `providers` parameter of the [StandardApp] widget.
+  ///
+  /// - [service] is an optional object which implements the [ACSysServiceAPI]
+  ///   interface. If this option is omitted, the widget will use communicate
+  ///   with the official GraphQL service.
+  /// - [key] is an optional identifier for the widget.
+
   static Widget Function({required Widget child}) factory({
     ACSysServiceAPI? service,
+    Key? key,
   }) =>
       ({required Widget child}) =>
-          ACSysProvider(service: service, child: child);
+          ACSysProvider._(service: service, key: key, child: child);
 
-  /// Creates the widget.
-  ///
-  /// - [child] is the widget subtree that gets added to the tree below this
-  ///   widget.
-  /// - [key] is an optional identifier for the widget.
-  /// - [service] is an optional obect which implements the [ACSysServiceAPI]
-  ///   interface. If this option is omitted, the widget will use an
-  ///   implementation that communicates over the network to the offcial
-  ///   control system API. This option is mainly to mock-up a service to
-  ///   use in unit tests.
-  const ACSysProvider({this.service, required this.child, super.key});
+  // Creates the widget.
+  //
+  // - [child] is the widget subtree that gets added to the tree below this
+  //   widget.
+  // - [key] is an optional identifier for the widget.
+  // - [service] is an optional obect which implements the [ACSysServiceAPI]
+  //   interface. If this option is omitted, the widget will use an
+  //   implementation that communicates over the network to the offcial
+  //   control system API. This option is mainly to mock-up a service to
+  //   use in unit tests.
+  const ACSysProvider._({this.service, required this.child, super.key});
 
   @override
   Widget build(BuildContext context) {
     return _ACSysProviderIW(
-      service: service ?? ACSysService(jwt: AuthService.getJwt(context)),
+      service: service ?? _ACSysService(jwt: AuthService.getJwt(context)),
       child: child,
     );
   }

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1306,7 +1306,7 @@ final class ACSys {
   /// get registered if the [ACSysProvider] gets rebuilt.
 
   static ACSysServiceAPI api(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<_ACSysProviderIW>()!._service;
+      context.dependOnInheritedWidgetOfExactType<_ACSysProviderIW>()!.service;
 }
 
 /// Provides the ACSys API to the application.
@@ -1363,14 +1363,11 @@ final class ACSysProvider extends StatelessWidget {
 // can be rapidly rebuilt when the service object changes.
 
 final class _ACSysProviderIW extends InheritedWidget {
-  final ACSysServiceAPI _service;
+  final ACSysServiceAPI service;
 
-  const _ACSysProviderIW({
-    required ACSysServiceAPI service,
-    required super.child,
-  }) : _service = service;
+  const _ACSysProviderIW({required this.service, required super.child});
 
   @override
   bool updateShouldNotify(covariant _ACSysProviderIW oldWidget) =>
-      _service != oldWidget._service;
+      service != oldWidget.service;
 }

--- a/lib/src/service/faas_service.dart
+++ b/lib/src/service/faas_service.dart
@@ -71,7 +71,7 @@ final class Faas {
   /// get registered if the [FaasProvider] gets rebuilt.
 
   static FaasServiceAPI api(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<_FaasProviderIW>()!._service;
+      context.dependOnInheritedWidgetOfExactType<_FaasProviderIW>()!.service;
 }
 
 /// Provides the FaaS API to the application.
@@ -135,12 +135,11 @@ final class FaasProvider extends StatelessWidget {
 // can be rapidly rebuilt when the service object changes.
 
 final class _FaasProviderIW extends InheritedWidget {
-  final FaasServiceAPI _service;
+  final FaasServiceAPI service;
 
-  const _FaasProviderIW({required FaasServiceAPI service, required super.child})
-    : _service = service;
+  const _FaasProviderIW({required this.service, required super.child});
 
   @override
   bool updateShouldNotify(covariant _FaasProviderIW oldWidget) =>
-      _service != oldWidget._service;
+      service != oldWidget.service;
 }

--- a/lib/src/service/faas_service.dart
+++ b/lib/src/service/faas_service.dart
@@ -61,8 +61,8 @@ final class _FaasService implements FaasServiceAPI {
 }
 
 /// A widget that provides access to the FaaS Service API. This doesn't
-/// exist in the widget, nor does it do anything but provide access to the
-/// API using the coolly named `Faas.api()` method.
+/// exist in the widget tree, nor does it do anything but provide access
+/// to the API using the `Faas.api()` method.
 
 final class Faas {
   /// Returns an object supporting the Faas API.
@@ -80,26 +80,47 @@ final class Faas {
 /// of this widget near the top of its tree so it doesn't get rebuilt. With
 /// this in the tree, other widgets can use the API by calling [Faas.api()]
 /// to get an [FaasServiceAPI] object which implements the API.
+///
+/// Although this widget can be created and placed in the tree manually, it is
+/// recommended to use the [FaasProvider.factory()] method to create this
+/// widget. This method returns a function that can be added to the list
+/// passed to the `providers` parameter of the [StandardApp] widget. Doing so
+/// ensures the FaaS provider can be used by all widgets in the application --
+/// even those in the [AppBar] and [Drawer] widgets. It also ensures that the
+/// widget has access to the [AthService] object so it can use authorization
+/// tokens to communicate with the FaaS API, if necessary.
 final class FaasProvider extends StatelessWidget {
   final Widget child;
   final FaasServiceAPI? service;
 
+  /// A factory function that creates a [FaasProvider] widget.
+  ///
+  /// This function returns a function that can be added to the list passed to
+  /// the `providers` parameter of the [StandardApp] widget.
+  ///
+  /// - [service] is an optional object which implements the [FaasServiceAPI]
+  ///   interface. If this option is omitted, the widget will use communicate
+  ///   with the official GraphQL service.
+  /// - [key] is an optional identifier for the widget.
+
   static Widget Function({required Widget child}) factory({
     FaasServiceAPI? service,
+    Key? key,
   }) =>
-      ({required Widget child}) => FaasProvider(service: service, child: child);
+      ({required Widget child}) =>
+          FaasProvider._(service: service, key: key, child: child);
 
-  /// Creates the widget.
-  ///
-  /// - [child] is the widget subtree that gets added to the tree below this
-  ///   widget.
-  /// - [key] is an optional identifier for the widget.
-  /// - [service] is an optional obect which implements the [FaasServiceAPI]
-  ///   interface. If this option is omitted, the widget will use an
-  ///   implementation that communicates over the network to the offcial
-  ///   control system API. This option is mainly to mock-up a service to
-  ///   use in unit tests.
-  const FaasProvider({this.service, required this.child, super.key});
+  // Creates the widget.
+  //
+  // - [child] is the widget subtree that gets added to the tree below this
+  //   widget.
+  // - [key] is an optional identifier for the widget.
+  // - [service] is an optional obect which implements the [FaasServiceAPI]
+  //   interface. If this option is omitted, the widget will use an
+  //   implementation that communicates over the network to the offcial
+  //   control system API. This option is mainly to mock-up a service to
+  //   use in unit tests.
+  const FaasProvider._({this.service, required this.child, super.key});
 
   @override
   Widget build(BuildContext context) => _FaasProviderIW(

--- a/lib/src/service/faas_service.dart
+++ b/lib/src/service/faas_service.dart
@@ -14,7 +14,7 @@ abstract interface class FaasServiceAPI {
   Future<Int64> unixToClinks(Int64 time);
 }
 
-final class FaasService implements FaasServiceAPI {
+final class _FaasService implements FaasServiceAPI {
   final Client _q;
 
   static Map<String, String> _buildAuthHeader(String? jwt) =>
@@ -23,7 +23,7 @@ final class FaasService implements FaasServiceAPI {
   // Constructor. This creates the HTTP link needed to communicate with our
   // GraphQL endpoint.
 
-  FaasService({String? jwt})
+  _FaasService({String? jwt})
     : _q = Client(
         link: HttpLink(
           "https://acsys-proxy.fnal.gov:8001/faas",
@@ -103,7 +103,7 @@ final class FaasProvider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => _FaasProviderIW(
-    service: service ?? FaasService(jwt: AuthService.getJwt(context)),
+    service: service ?? _FaasService(jwt: AuthService.getJwt(context)),
     child: child,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.2.13
+version: 0.2.14
 
 environment:
     sdk: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
Adds doc comments and tightens access to widgets. For instance, you now have to use the factory methods to create `FassProvider` and `ACSysProvider` widgets. Plus, you can no longer create instances of `FassService` or `ACSysService`.