### PR TITLE
Restore `PlotPoint`

### DIFF
--- a/lib/src/service/acsys/schema/DPM.graphql
+++ b/lib/src/service/acsys/schema/DPM.graphql
@@ -197,6 +197,10 @@ Contains plot data for a given plot request.
 """
 type PlotReplyData {
   """
+  If the plot uses a clock for the trigger, this is the timestamp of the event.
+  """
+  tstamp: Float
+  """
   A unique identifier for the plot request. This identifier will be cached for a limited time. Other clients can specify it to re-use the configuration.
   """
   plotId: String!

--- a/lib/src/service/acsys/schema/__generated__/DPM.ast.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/DPM.ast.gql.dart
@@ -721,6 +721,15 @@ const PlotReplyData = _i1.ObjectTypeDefinitionNode(
   interfaces: [],
   fields: [
     _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'tstamp'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Float'),
+        isNonNull: false,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
       name: _i1.NameNode(value: 'plotId'),
       directives: [],
       args: [],

--- a/lib/src/service/acsys/schema/__generated__/start_plot.ast.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.ast.gql.dart
@@ -115,6 +115,13 @@ const StartPlot = _i1.OperationDefinitionNode(
         selectionSet: _i1.SelectionSetNode(
           selections: [
             _i1.FieldNode(
+              name: _i1.NameNode(value: 'tstamp'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: null,
+            ),
+            _i1.FieldNode(
               name: _i1.NameNode(value: 'plotId'),
               alias: null,
               arguments: [],

--- a/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.dart
@@ -48,6 +48,7 @@ abstract class GStartPlotData_startPlot
 
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
+  double? get tstamp;
   String get plotId;
   BuiltList<GStartPlotData_startPlot_data> get data;
   static Serializer<GStartPlotData_startPlot> get serializer =>

--- a/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.g.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.g.dart
@@ -119,7 +119,15 @@ class _$GStartPlotData_startPlotSerializer
         ]),
       ),
     ];
-
+    Object? value;
+    value = object.tstamp;
+    if (value != null) {
+      result
+        ..add('tstamp')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(double)),
+        );
+    }
     return result;
   }
 
@@ -144,6 +152,14 @@ class _$GStartPlotData_startPlotSerializer
                     specifiedType: const FullType(String),
                   )!
                   as String;
+          break;
+        case 'tstamp':
+          result.tstamp =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(double),
+                  )
+                  as double?;
           break;
         case 'plotId':
           result.plotId =
@@ -482,6 +498,8 @@ class _$GStartPlotData_startPlot extends GStartPlotData_startPlot {
   @override
   final String G__typename;
   @override
+  final double? tstamp;
+  @override
   final String plotId;
   @override
   final BuiltList<GStartPlotData_startPlot_data> data;
@@ -492,6 +510,7 @@ class _$GStartPlotData_startPlot extends GStartPlotData_startPlot {
 
   _$GStartPlotData_startPlot._({
     required this.G__typename,
+    this.tstamp,
     required this.plotId,
     required this.data,
   }) : super._() {
@@ -526,6 +545,7 @@ class _$GStartPlotData_startPlot extends GStartPlotData_startPlot {
     if (identical(other, this)) return true;
     return other is GStartPlotData_startPlot &&
         G__typename == other.G__typename &&
+        tstamp == other.tstamp &&
         plotId == other.plotId &&
         data == other.data;
   }
@@ -534,6 +554,7 @@ class _$GStartPlotData_startPlot extends GStartPlotData_startPlot {
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, tstamp.hashCode);
     _$hash = $jc(_$hash, plotId.hashCode);
     _$hash = $jc(_$hash, data.hashCode);
     _$hash = $jf(_$hash);
@@ -544,6 +565,7 @@ class _$GStartPlotData_startPlot extends GStartPlotData_startPlot {
   String toString() {
     return (newBuiltValueToStringHelper(r'GStartPlotData_startPlot')
           ..add('G__typename', G__typename)
+          ..add('tstamp', tstamp)
           ..add('plotId', plotId)
           ..add('data', data))
         .toString();
@@ -558,6 +580,10 @@ class GStartPlotData_startPlotBuilder
   String? _G__typename;
   String? get G__typename => _$this._G__typename;
   set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  double? _tstamp;
+  double? get tstamp => _$this._tstamp;
+  set tstamp(double? tstamp) => _$this._tstamp = tstamp;
 
   String? _plotId;
   String? get plotId => _$this._plotId;
@@ -577,6 +603,7 @@ class GStartPlotData_startPlotBuilder
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
+      _tstamp = $v.tstamp;
       _plotId = $v.plotId;
       _data = $v.data.toBuilder();
       _$v = null;
@@ -609,6 +636,7 @@ class GStartPlotData_startPlotBuilder
               r'GStartPlotData_startPlot',
               'G__typename',
             ),
+            tstamp: tstamp,
             plotId: BuiltValueNullFieldError.checkNotNull(
               plotId,
               r'GStartPlotData_startPlot',

--- a/lib/src/service/acsys/schema/start_plot.graphql
+++ b/lib/src/service/acsys/schema/start_plot.graphql
@@ -1,5 +1,6 @@
 subscription StartPlot($drfList: [String!]!, $xMin: Float, $xMax: Float, $windowSize: Int, $updateDelay: Int, $nAcquisitions: Int, $triggerEvent: Int) {
   startPlot(drfList: $drfList, xMin: $xMin, xMax: $xMax, windowSize: $windowSize, updateDelay: $updateDelay, nAcquisitions: $nAcquisitions, triggerEvent: $triggerEvent) {
+    tstamp
     plotId
     data {
       channelUnits

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -371,14 +371,22 @@ final class PlotChannelData {
   final String name;
   final String units;
   final int status;
-  final DevTimeSeries data;
+  final List<PlotPoint> points;
 
   const PlotChannelData({
     required this.name,
     required this.units,
     this.status = 0,
-    this.data = const DevTimeSeries([]),
+    this.points = const [],
   });
+}
+
+final class PlotPoint {
+  final double? t;
+  final double x;
+  final double y;
+
+  const PlotPoint({required this.x, required this.y, this.t});
 }
 
 final class ChannelSettingSnapshot {
@@ -1044,7 +1052,7 @@ final class ACSysService implements ACSysServiceAPI {
         .request(req)
         .handleError((error) => dev.log("error: $error", name: "gql.startPlot"))
         .where((event) => !event.loading)
-        .map((e) => e.data!.startPlot.toPlotReply(req));
+        .map((e) => e.data!.startPlot.toPlotReply(req, null));
   }
 
   @override
@@ -1267,23 +1275,28 @@ extension on GReadDevicesData_acceleratorData_data_result {
 }
 
 extension on GStartPlotData_startPlot_data {
-  PlotChannelData toPlotChannelData(int idx, GStartPlotReq req) =>
+  PlotChannelData toPlotChannelData(int idx, double? ts, GStartPlotReq req) =>
       PlotChannelData(
         name: req.vars.drfList[idx],
         units: channelUnits,
         status: channelStatus,
-        data: DevTimeSeries([...channelData.map((e) => (e.x, e.y))]),
+        points: [
+          ...channelData.map(
+            (e) => PlotPoint(t: ts, x: e.x - (ts ?? 0.0), y: e.y),
+          ),
+        ],
       );
 }
 
 extension on GStartPlotData_startPlot {
-  PlotReply toPlotReply(GStartPlotReq req) => PlotReply(
+  PlotReply toPlotReply(GStartPlotReq req, double? ts) => PlotReply(
     plotId: plotId,
     xAxisUnits: "Time",
     xAxisMin: req.vars.xMin?.toDouble(),
     xAxisMax: req.vars.xMax?.toDouble(),
     windowSize: req.vars.windowSize,
-    data: data.indexed.map((e) => e.$2.toPlotChannelData(e.$1, req)).toList(),
+    data:
+        data.indexed.map((e) => e.$2.toPlotChannelData(e.$1, ts, req)).toList(),
   );
 }
 

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1052,7 +1052,7 @@ final class ACSysService implements ACSysServiceAPI {
         .request(req)
         .handleError((error) => dev.log("error: $error", name: "gql.startPlot"))
         .where((event) => !event.loading)
-        .map((e) => e.data!.startPlot.toPlotReply(req, null));
+        .map((e) => e.data!.startPlot.toPlotReply(req));
   }
 
   @override
@@ -1289,14 +1289,16 @@ extension on GStartPlotData_startPlot_data {
 }
 
 extension on GStartPlotData_startPlot {
-  PlotReply toPlotReply(GStartPlotReq req, double? ts) => PlotReply(
+  PlotReply toPlotReply(GStartPlotReq req) => PlotReply(
     plotId: plotId,
     xAxisUnits: "Time",
     xAxisMin: req.vars.xMin?.toDouble(),
     xAxisMax: req.vars.xMax?.toDouble(),
     windowSize: req.vars.windowSize,
     data:
-        data.indexed.map((e) => e.$2.toPlotChannelData(e.$1, ts, req)).toList(),
+        data.indexed
+            .map((e) => e.$2.toPlotChannelData(e.$1, tstamp, req))
+            .toList(),
   );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.2.16
+version: 0.2.17
 
 environment:
     sdk: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
This updates the GraphQL `startPlot` query to match the service's schema which, in turn, includes new fields to help with plots triggered by a clock event. This version *should* match what the Plotting app is expecting. If not, let me know.

The rest of this support is in the GraphQL resolver. It'll have to subscribe to the Clock gRPC service to be able to get timestamps for the events of interest and process the stream of points so they are partitioned into correct groups.

I mention this because it's probably safe to merge this pull request, but you won't see the data plotted correctly until those changes in the resolver are finalized