### PR TITLE
Two updates

### DIFF
--- a/lib/src/auth_widget.dart
+++ b/lib/src/auth_widget.dart
@@ -35,7 +35,7 @@ Future<void> initAuth(
   String clientSecret,
   List<String> scopes,
 ) async {
-  final uri = Uri.parse('https://adkube-auth.fnal.gov/realms/$realm/');
+  final uri = Uri.parse('https://ad-auth.fnal.gov/realms/$realm/');
   const Duration tmo = Duration(seconds: 2);
 
   _authRequired = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.2.18
+version: 0.2.19
 
 environment:
     sdk: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
- We made the `t` field in `PlotDataPoint` strict (i.e. not nullable)
- We're now using the new KeyCloak service that's available outside the firewall. Applications using v0.2.19 will have to get new application credentials.