### PR TITLE
Revert "use new KeyCloak URL"

### DIFF
--- a/lib/src/auth_widget.dart
+++ b/lib/src/auth_widget.dart
@@ -35,7 +35,7 @@ Future<void> initAuth(
   String clientSecret,
   List<String> scopes,
 ) async {
-  final uri = Uri.parse('https://ad-auth.fnal.gov/realms/$realm/');
+  final uri = Uri.parse('https://adkube-auth.fnal.gov/realms/$realm/');
   const Duration tmo = Duration(seconds: 2);
 
   _authRequired = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.2.19
+version: 0.2.20
 
 environment:
     sdk: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
We'll use the new service in the `v0.3.x` branch. Right now the plotting app needs a stable branch.