### PR TITLE
Add `channelRate` support

### DIFF
--- a/lib/src/service/acsys/schema/DPM.graphql
+++ b/lib/src/service/acsys/schema/DPM.graphql
@@ -29,7 +29,7 @@ This structure holds information associated with a device's reading, A "reading"
 """
 type DataInfo {
   """
-  Timestamp representing when the data was sampled. This value is provided as milliseconds since 1970, UTC.
+  Timestamp representing when the data was sampled. This value is provided as seconds since 1970, UTC. The fractional portion of the value can represent nanoseconds, but we have few -- if any -- systems that provide that resolution.
   """
   timestamp: Float!
 
@@ -39,7 +39,7 @@ type DataInfo {
   result: DataType!
 
   """
-  The device's index (in the device database.)
+  The device's index (in the device database.) This field may get removed; its purpose is questionable in this API.
   """
   di: Int!
 
@@ -48,6 +48,9 @@ type DataInfo {
   """
   name: String!
 
+  """
+  The timestamp as an ISO formatted string. This value is fairly expensive to generate, so the `timestamp` field should be preferred to this one. This field is mainly used for debugging or when using a tool that returns human-readable results.
+  """
   isoTimestamp: Timestamp!
 }
 
@@ -124,12 +127,34 @@ type Mutation {
   ): StatusReply!
   updatePlotConfiguration(config: PlotConfigurationSnapshotIn!): Int
   deletePlotConfiguration(configurationId: Int!): StatusReply!
+
+  """
+  Sets the user's default configuration.
+
+  The content of the configuration are used to set the default configuration for the user. All fields, except the ID and name fields, are used. The user's account name is obtained from the authentication token that accompanies the request.
+  """
   usersConfiguration(config: PlotConfigurationSnapshotIn!): StatusReply!
 }
 
 type PlotChannelData {
+  """
+  The engineering units of the device.
+  """
   channelUnits: String!
+
+  """
+  The negotiated return rate for the data. If a device's readings are requested at a higher rate than the device can support, the front-end will negotiate down to an acheivable rate. This field represents the actual sample rate of the data.
+  """
+  channelRate: String!
+
+  """
+  The global status of the reading. This field will either be `0` (successful reads) or a negative status, indicating a fatal error occurred trying to get the device's data.
+  """
   channelStatus: Int!
+
+  """
+  A set of data points. If the return rate is slow (<= 1Hz), this list will only have one element.
+  """
   channelData: [PlotDataPoint!]!
 }
 
@@ -137,7 +162,7 @@ type PlotConfigurationSnapshot {
   """
   Unique identifier for the plot configuration
   """
-  configurationId: Int!
+  configurationId: Int
   configurationName: String!
   channels: [ChannelSettingSnapshot!]!
   xMin: Float
@@ -148,6 +173,8 @@ type PlotConfigurationSnapshot {
   isScalar: Boolean!
   isOneShot: Boolean!
   isShowLabels: Boolean!
+  isPersistent: Boolean!
+  dataLimit: Int!
 
   """
   If `triggerEvent` is null, this parameter specifies the delay, in milliseconds, between points in a waveform. If a trigger event is specified, then this specifies the delay after the event when the signal should be sampled. If this parameter is null, then there will be no delay after a trigger event or a 1 Hz sample rate will be used.
@@ -159,8 +186,6 @@ type PlotConfigurationSnapshot {
   """
   nAcquisitions: Int
   tclkEvent: Int
-  isPersistent: Boolean!
-  dataLimit: Int!
 }
 
 input PlotConfigurationSnapshotIn {
@@ -178,6 +203,8 @@ input PlotConfigurationSnapshotIn {
   isScalar: Boolean!
   isOneShot: Boolean!
   isShowLabels: Boolean!
+  isPersistent: Boolean!
+  dataLimit: Int!
 
   """
   If `triggerEvent` is null, this parameter specifies the delay, in milliseconds, between points in a waveform. If a trigger event is specified, then this specifies the delay after the event when the signal should be sampled. If this parameter is null, then there will be no delay after a trigger event or a 1 Hz sample rate will be used.
@@ -189,8 +216,6 @@ input PlotConfigurationSnapshotIn {
   """
   nAcquisitions: Int
   tclkEvent: Int
-  isPersistent: Boolean!
-  dataLimit: Int!
 }
 
 type PlotDataPoint {
@@ -203,9 +228,6 @@ type PlotDataPoint {
 Contains plot data for a given plot request.
 """
 type PlotReplyData {
-  """
-  If the plot uses a clock for the trigger, this is the timestamp of the event.
-  """
   timestamp: Float!
   """
   A unique identifier for the plot request. This identifier will be cached for a limited time. Other clients can specify it to re-use the configuration.
@@ -220,9 +242,9 @@ Fields in this section return data and won't cause side-effects in the control s
 """
 type Query {
   """
-  Retrieve the next data point for the specified devices. Depending upon the event in the DRF string, the data may come back immediately or after a delay.
+  Retrieve the next data point for the specified devices.
 
-  *NOTE: This query hasn't been implemented yet.*
+  Depending upon the event in the DRF string, the data may come back immediately or after a delay.
   """
   acceleratorData(
     """
@@ -235,8 +257,32 @@ type Query {
     """
     when: Timestamp
   ): [DataReply!]!
+
+  """
+  Retrieve plot configuration(s).
+
+  Returns a plot configuration associated with the specified ID. If the ID is `null`, all configurations are returned. Both style of requests return an array result -- it's just that specifying an ID will return an array with 0 or 1 element.
+  """
   plotConfiguration(configurationId: Int): [PlotConfigurationSnapshot!]!
-  usersLastConfiguration(): PlotConfigurationSnapshot
+
+  """
+  Obtain the user's last configuration.
+
+  If the application saved the user's last plot configuration, this query will return it. If there is no configuration for the user, `null` is returned. The user's account is retrieved from the authentication token that is included in the request.
+  """
+  usersLastConfiguration: PlotConfigurationSnapshot
+
+  """
+  Converts "clinks" to a Unix timestamp (seconds since Jan 1, 1970 UTC.)
+  """
+  clinksToUnix(clinks: Int!): Int!
+    @deprecated(reason: "This is a test API and will be removed.")
+
+  """
+  Converts a Unix timestamp (seconds since Jan 1, 1970 UTC) into "clinks". Since there is a range of Unix time that can't be represented in "clinks", `null` will be returned when the conversion fails.
+  """
+  unixToClinks(time: Int!): Int
+    @deprecated(reason: "This is a test API and will be removed.")
 }
 
 """
@@ -337,7 +383,7 @@ type Subscription {
     nAcquisitions: Int
 
     """
-    If `triggerEvent` is null, this parameter specifies the delay, in milliseconds, between points in a waveform. If a trigger event is specified, then this specifies the delay after the event when the signal should be sampled. If this parameter is null, then there will be no delay after a trigger event or a 1 Hz sample rate will be used.
+    If `triggerEvent` is null, this parameter specifies the delay, in microseconds, between points in a waveform. If a trigger event is specified, then this specifies the delay after the event when the signal should be sampled. If this parameter is null, then there will be no delay after a trigger event or a 1 Hz sample rate will be used.
     """
     updateDelay: Int
 
@@ -355,8 +401,6 @@ type Subscription {
     Maximum timestamp. All data after this timestamp will be filtered from the result set.
     """
     xMax: Float
-    nAcquisitions: Int
-    triggerEvent: Int
   ): PlotReplyData!
   reportEvents(events: [Int!]!): EventInfo!
   calcStream(config: XformRequest!): XformResult!

--- a/lib/src/service/acsys/schema/__generated__/DPM.ast.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/DPM.ast.gql.dart
@@ -406,6 +406,15 @@ const PlotChannelData = _i1.ObjectTypeDefinitionNode(
       ),
     ),
     _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'channelRate'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
       name: _i1.NameNode(value: 'channelStatus'),
       directives: [],
       args: [],
@@ -439,7 +448,7 @@ const PlotConfigurationSnapshot = _i1.ObjectTypeDefinitionNode(
       args: [],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Int'),
-        isNonNull: true,
+        isNonNull: false,
       ),
     ),
     _i1.FieldDefinitionNode(
@@ -536,6 +545,24 @@ const PlotConfigurationSnapshot = _i1.ObjectTypeDefinitionNode(
       ),
     ),
     _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'isPersistent'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Boolean'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'dataLimit'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Int'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
       name: _i1.NameNode(value: 'updateDelay'),
       directives: [],
       args: [],
@@ -560,24 +587,6 @@ const PlotConfigurationSnapshot = _i1.ObjectTypeDefinitionNode(
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Int'),
         isNonNull: false,
-      ),
-    ),
-    _i1.FieldDefinitionNode(
-      name: _i1.NameNode(value: 'isPersistent'),
-      directives: [],
-      args: [],
-      type: _i1.NamedTypeNode(
-        name: _i1.NameNode(value: 'Boolean'),
-        isNonNull: true,
-      ),
-    ),
-    _i1.FieldDefinitionNode(
-      name: _i1.NameNode(value: 'dataLimit'),
-      directives: [],
-      args: [],
-      type: _i1.NamedTypeNode(
-        name: _i1.NameNode(value: 'Int'),
-        isNonNull: true,
       ),
     ),
   ],
@@ -689,6 +698,24 @@ const PlotConfigurationSnapshotIn = _i1.InputObjectTypeDefinitionNode(
       defaultValue: null,
     ),
     _i1.InputValueDefinitionNode(
+      name: _i1.NameNode(value: 'isPersistent'),
+      directives: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Boolean'),
+        isNonNull: true,
+      ),
+      defaultValue: null,
+    ),
+    _i1.InputValueDefinitionNode(
+      name: _i1.NameNode(value: 'dataLimit'),
+      directives: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Int'),
+        isNonNull: true,
+      ),
+      defaultValue: null,
+    ),
+    _i1.InputValueDefinitionNode(
       name: _i1.NameNode(value: 'updateDelay'),
       directives: [],
       type: _i1.NamedTypeNode(
@@ -712,24 +739,6 @@ const PlotConfigurationSnapshotIn = _i1.InputObjectTypeDefinitionNode(
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Int'),
         isNonNull: false,
-      ),
-      defaultValue: null,
-    ),
-    _i1.InputValueDefinitionNode(
-      name: _i1.NameNode(value: 'isPersistent'),
-      directives: [],
-      type: _i1.NamedTypeNode(
-        name: _i1.NameNode(value: 'Boolean'),
-        isNonNull: true,
-      ),
-      defaultValue: null,
-    ),
-    _i1.InputValueDefinitionNode(
-      name: _i1.NameNode(value: 'dataLimit'),
-      directives: [],
-      type: _i1.NamedTypeNode(
-        name: _i1.NameNode(value: 'Int'),
-        isNonNull: true,
       ),
       defaultValue: null,
     ),
@@ -882,6 +891,70 @@ const Query = _i1.ObjectTypeDefinitionNode(
       args: [],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'PlotConfigurationSnapshot'),
+        isNonNull: false,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'clinksToUnix'),
+      directives: [
+        _i1.DirectiveNode(
+          name: _i1.NameNode(value: 'deprecated'),
+          arguments: [
+            _i1.ArgumentNode(
+              name: _i1.NameNode(value: 'reason'),
+              value: _i1.StringValueNode(
+                value: 'This is a test API and will be removed.',
+                isBlock: false,
+              ),
+            ),
+          ],
+        ),
+      ],
+      args: [
+        _i1.InputValueDefinitionNode(
+          name: _i1.NameNode(value: 'clinks'),
+          directives: [],
+          type: _i1.NamedTypeNode(
+            name: _i1.NameNode(value: 'Int'),
+            isNonNull: true,
+          ),
+          defaultValue: null,
+        ),
+      ],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Int'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'unixToClinks'),
+      directives: [
+        _i1.DirectiveNode(
+          name: _i1.NameNode(value: 'deprecated'),
+          arguments: [
+            _i1.ArgumentNode(
+              name: _i1.NameNode(value: 'reason'),
+              value: _i1.StringValueNode(
+                value: 'This is a test API and will be removed.',
+                isBlock: false,
+              ),
+            ),
+          ],
+        ),
+      ],
+      args: [
+        _i1.InputValueDefinitionNode(
+          name: _i1.NameNode(value: 'time'),
+          directives: [],
+          type: _i1.NamedTypeNode(
+            name: _i1.NameNode(value: 'Int'),
+            isNonNull: true,
+          ),
+          defaultValue: null,
+        ),
+      ],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Int'),
         isNonNull: false,
       ),
     ),
@@ -1161,24 +1234,6 @@ const Subscription = _i1.ObjectTypeDefinitionNode(
           directives: [],
           type: _i1.NamedTypeNode(
             name: _i1.NameNode(value: 'Float'),
-            isNonNull: false,
-          ),
-          defaultValue: null,
-        ),
-        _i1.InputValueDefinitionNode(
-          name: _i1.NameNode(value: 'nAcquisitions'),
-          directives: [],
-          type: _i1.NamedTypeNode(
-            name: _i1.NameNode(value: 'Int'),
-            isNonNull: false,
-          ),
-          defaultValue: null,
-        ),
-        _i1.InputValueDefinitionNode(
-          name: _i1.NameNode(value: 'triggerEvent'),
-          directives: [],
-          type: _i1.NamedTypeNode(
-            name: _i1.NameNode(value: 'Int'),
             isNonNull: false,
           ),
           defaultValue: null,

--- a/lib/src/service/acsys/schema/__generated__/DPM.schema.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/DPM.schema.gql.dart
@@ -79,11 +79,11 @@ abstract class GPlotConfigurationSnapshotIn
   bool get isScalar;
   bool get isOneShot;
   bool get isShowLabels;
+  bool get isPersistent;
+  int get dataLimit;
   int? get updateDelay;
   int? get nAcquisitions;
   int? get tclkEvent;
-  bool get isPersistent;
-  int get dataLimit;
   static Serializer<GPlotConfigurationSnapshotIn> get serializer =>
       _$gPlotConfigurationSnapshotInSerializer;
 

--- a/lib/src/service/acsys/schema/__generated__/DPM.schema.gql.g.dart
+++ b/lib/src/service/acsys/schema/__generated__/DPM.schema.gql.g.dart
@@ -502,21 +502,6 @@ class _$GPlotConfigurationSnapshotInSerializer
                   )!
                   as bool;
           break;
-        case 'updateDelay':
-          result.updateDelay =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
-          break;
-        case 'nAcquisitions':
-          result.nAcquisitions =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
-          break;
-        case 'tclkEvent':
-          result.tclkEvent =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
-          break;
         case 'isPersistent':
           result.isPersistent =
               serializers.deserialize(
@@ -532,6 +517,21 @@ class _$GPlotConfigurationSnapshotInSerializer
                     specifiedType: const FullType(int),
                   )!
                   as int;
+          break;
+        case 'updateDelay':
+          result.updateDelay =
+              serializers.deserialize(value, specifiedType: const FullType(int))
+                  as int?;
+          break;
+        case 'nAcquisitions':
+          result.nAcquisitions =
+              serializers.deserialize(value, specifiedType: const FullType(int))
+                  as int?;
+          break;
+        case 'tclkEvent':
+          result.tclkEvent =
+              serializers.deserialize(value, specifiedType: const FullType(int))
+                  as int?;
           break;
       }
     }
@@ -1198,15 +1198,15 @@ class _$GPlotConfigurationSnapshotIn extends GPlotConfigurationSnapshotIn {
   @override
   final bool isShowLabels;
   @override
+  final bool isPersistent;
+  @override
+  final int dataLimit;
+  @override
   final int? updateDelay;
   @override
   final int? nAcquisitions;
   @override
   final int? tclkEvent;
-  @override
-  final bool isPersistent;
-  @override
-  final int dataLimit;
 
   factory _$GPlotConfigurationSnapshotIn([
     void Function(GPlotConfigurationSnapshotInBuilder)? updates,
@@ -1224,11 +1224,11 @@ class _$GPlotConfigurationSnapshotIn extends GPlotConfigurationSnapshotIn {
     required this.isScalar,
     required this.isOneShot,
     required this.isShowLabels,
+    required this.isPersistent,
+    required this.dataLimit,
     this.updateDelay,
     this.nAcquisitions,
     this.tclkEvent,
-    required this.isPersistent,
-    required this.dataLimit,
   }) : super._() {
     BuiltValueNullFieldError.checkNotNull(
       configurationName,
@@ -1291,11 +1291,11 @@ class _$GPlotConfigurationSnapshotIn extends GPlotConfigurationSnapshotIn {
         isScalar == other.isScalar &&
         isOneShot == other.isOneShot &&
         isShowLabels == other.isShowLabels &&
+        isPersistent == other.isPersistent &&
+        dataLimit == other.dataLimit &&
         updateDelay == other.updateDelay &&
         nAcquisitions == other.nAcquisitions &&
-        tclkEvent == other.tclkEvent &&
-        isPersistent == other.isPersistent &&
-        dataLimit == other.dataLimit;
+        tclkEvent == other.tclkEvent;
   }
 
   @override
@@ -1312,11 +1312,11 @@ class _$GPlotConfigurationSnapshotIn extends GPlotConfigurationSnapshotIn {
     _$hash = $jc(_$hash, isScalar.hashCode);
     _$hash = $jc(_$hash, isOneShot.hashCode);
     _$hash = $jc(_$hash, isShowLabels.hashCode);
+    _$hash = $jc(_$hash, isPersistent.hashCode);
+    _$hash = $jc(_$hash, dataLimit.hashCode);
     _$hash = $jc(_$hash, updateDelay.hashCode);
     _$hash = $jc(_$hash, nAcquisitions.hashCode);
     _$hash = $jc(_$hash, tclkEvent.hashCode);
-    _$hash = $jc(_$hash, isPersistent.hashCode);
-    _$hash = $jc(_$hash, dataLimit.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -1335,11 +1335,11 @@ class _$GPlotConfigurationSnapshotIn extends GPlotConfigurationSnapshotIn {
           ..add('isScalar', isScalar)
           ..add('isOneShot', isOneShot)
           ..add('isShowLabels', isShowLabels)
+          ..add('isPersistent', isPersistent)
+          ..add('dataLimit', dataLimit)
           ..add('updateDelay', updateDelay)
           ..add('nAcquisitions', nAcquisitions)
-          ..add('tclkEvent', tclkEvent)
-          ..add('isPersistent', isPersistent)
-          ..add('dataLimit', dataLimit))
+          ..add('tclkEvent', tclkEvent))
         .toString();
   }
 }
@@ -1400,6 +1400,14 @@ class GPlotConfigurationSnapshotInBuilder
   bool? get isShowLabels => _$this._isShowLabels;
   set isShowLabels(bool? isShowLabels) => _$this._isShowLabels = isShowLabels;
 
+  bool? _isPersistent;
+  bool? get isPersistent => _$this._isPersistent;
+  set isPersistent(bool? isPersistent) => _$this._isPersistent = isPersistent;
+
+  int? _dataLimit;
+  int? get dataLimit => _$this._dataLimit;
+  set dataLimit(int? dataLimit) => _$this._dataLimit = dataLimit;
+
   int? _updateDelay;
   int? get updateDelay => _$this._updateDelay;
   set updateDelay(int? updateDelay) => _$this._updateDelay = updateDelay;
@@ -1412,14 +1420,6 @@ class GPlotConfigurationSnapshotInBuilder
   int? _tclkEvent;
   int? get tclkEvent => _$this._tclkEvent;
   set tclkEvent(int? tclkEvent) => _$this._tclkEvent = tclkEvent;
-
-  bool? _isPersistent;
-  bool? get isPersistent => _$this._isPersistent;
-  set isPersistent(bool? isPersistent) => _$this._isPersistent = isPersistent;
-
-  int? _dataLimit;
-  int? get dataLimit => _$this._dataLimit;
-  set dataLimit(int? dataLimit) => _$this._dataLimit = dataLimit;
 
   GPlotConfigurationSnapshotInBuilder();
 
@@ -1437,11 +1437,11 @@ class GPlotConfigurationSnapshotInBuilder
       _isScalar = $v.isScalar;
       _isOneShot = $v.isOneShot;
       _isShowLabels = $v.isShowLabels;
+      _isPersistent = $v.isPersistent;
+      _dataLimit = $v.dataLimit;
       _updateDelay = $v.updateDelay;
       _nAcquisitions = $v.nAcquisitions;
       _tclkEvent = $v.tclkEvent;
-      _isPersistent = $v.isPersistent;
-      _dataLimit = $v.dataLimit;
       _$v = null;
     }
     return this;
@@ -1494,9 +1494,6 @@ class GPlotConfigurationSnapshotInBuilder
               r'GPlotConfigurationSnapshotIn',
               'isShowLabels',
             ),
-            updateDelay: updateDelay,
-            nAcquisitions: nAcquisitions,
-            tclkEvent: tclkEvent,
             isPersistent: BuiltValueNullFieldError.checkNotNull(
               isPersistent,
               r'GPlotConfigurationSnapshotIn',
@@ -1507,6 +1504,9 @@ class GPlotConfigurationSnapshotInBuilder
               r'GPlotConfigurationSnapshotIn',
               'dataLimit',
             ),
+            updateDelay: updateDelay,
+            nAcquisitions: nAcquisitions,
+            tclkEvent: tclkEvent,
           );
     } catch (_) {
       late String _$failedField;

--- a/lib/src/service/acsys/schema/__generated__/plot_configs.data.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/plot_configs.data.gql.dart
@@ -51,7 +51,7 @@ abstract class GPlotConfigsData_plotConfiguration
 
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  int get configurationId;
+  int? get configurationId;
   String get configurationName;
   BuiltList<GPlotConfigsData_plotConfiguration_channels> get channels;
   double? get xMin;

--- a/lib/src/service/acsys/schema/__generated__/plot_configs.data.gql.g.dart
+++ b/lib/src/service/acsys/schema/__generated__/plot_configs.data.gql.g.dart
@@ -108,11 +108,6 @@ class _$GPlotConfigsData_plotConfigurationSerializer
         object.G__typename,
         specifiedType: const FullType(String),
       ),
-      'configurationId',
-      serializers.serialize(
-        object.configurationId,
-        specifiedType: const FullType(int),
-      ),
       'configurationName',
       serializers.serialize(
         object.configurationName,
@@ -152,6 +147,12 @@ class _$GPlotConfigsData_plotConfigurationSerializer
       ),
     ];
     Object? value;
+    value = object.configurationId;
+    if (value != null) {
+      result
+        ..add('configurationId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     value = object.xMin;
     if (value != null) {
       result
@@ -237,11 +238,8 @@ class _$GPlotConfigsData_plotConfigurationSerializer
           break;
         case 'configurationId':
           result.configurationId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(int),
-                  )!
-                  as int;
+              serializers.deserialize(value, specifiedType: const FullType(int))
+                  as int?;
           break;
         case 'configurationName':
           result.configurationName =
@@ -597,7 +595,7 @@ class _$GPlotConfigsData_plotConfiguration
   @override
   final String G__typename;
   @override
-  final int configurationId;
+  final int? configurationId;
   @override
   final String configurationName;
   @override
@@ -637,7 +635,7 @@ class _$GPlotConfigsData_plotConfiguration
 
   _$GPlotConfigsData_plotConfiguration._({
     required this.G__typename,
-    required this.configurationId,
+    this.configurationId,
     required this.configurationName,
     required this.channels,
     this.xMin,
@@ -658,11 +656,6 @@ class _$GPlotConfigsData_plotConfiguration
       G__typename,
       r'GPlotConfigsData_plotConfiguration',
       'G__typename',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      configurationId,
-      r'GPlotConfigsData_plotConfiguration',
-      'configurationId',
     );
     BuiltValueNullFieldError.checkNotNull(
       configurationName,
@@ -920,11 +913,7 @@ class GPlotConfigsData_plotConfigurationBuilder
               r'GPlotConfigsData_plotConfiguration',
               'G__typename',
             ),
-            configurationId: BuiltValueNullFieldError.checkNotNull(
-              configurationId,
-              r'GPlotConfigsData_plotConfiguration',
-              'configurationId',
-            ),
+            configurationId: configurationId,
             configurationName: BuiltValueNullFieldError.checkNotNull(
               configurationName,
               r'GPlotConfigsData_plotConfiguration',

--- a/lib/src/service/acsys/schema/__generated__/start_plot.ast.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.ast.gql.dart
@@ -136,6 +136,13 @@ const StartPlot = _i1.OperationDefinitionNode(
               selectionSet: _i1.SelectionSetNode(
                 selections: [
                   _i1.FieldNode(
+                    name: _i1.NameNode(value: 'channelRate'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  _i1.FieldNode(
                     name: _i1.NameNode(value: 'channelUnits'),
                     alias: null,
                     arguments: [],

--- a/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.dart
@@ -80,6 +80,7 @@ abstract class GStartPlotData_startPlot_data
 
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
+  String get channelRate;
   String get channelUnits;
   int get channelStatus;
   BuiltList<GStartPlotData_startPlot_data_channelData> get channelData;

--- a/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.g.dart
+++ b/lib/src/service/acsys/schema/__generated__/start_plot.data.gql.g.dart
@@ -206,6 +206,11 @@ class _$GStartPlotData_startPlot_dataSerializer
         object.G__typename,
         specifiedType: const FullType(String),
       ),
+      'channelRate',
+      serializers.serialize(
+        object.channelRate,
+        specifiedType: const FullType(String),
+      ),
       'channelUnits',
       serializers.serialize(
         object.channelUnits,
@@ -244,6 +249,14 @@ class _$GStartPlotData_startPlot_dataSerializer
       switch (key) {
         case '__typename':
           result.G__typename =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(String),
+                  )!
+                  as String;
+          break;
+        case 'channelRate':
+          result.channelRate =
               serializers.deserialize(
                     value,
                     specifiedType: const FullType(String),
@@ -683,6 +696,8 @@ class _$GStartPlotData_startPlot_data extends GStartPlotData_startPlot_data {
   @override
   final String G__typename;
   @override
+  final String channelRate;
+  @override
   final String channelUnits;
   @override
   final int channelStatus;
@@ -695,6 +710,7 @@ class _$GStartPlotData_startPlot_data extends GStartPlotData_startPlot_data {
 
   _$GStartPlotData_startPlot_data._({
     required this.G__typename,
+    required this.channelRate,
     required this.channelUnits,
     required this.channelStatus,
     required this.channelData,
@@ -703,6 +719,11 @@ class _$GStartPlotData_startPlot_data extends GStartPlotData_startPlot_data {
       G__typename,
       r'GStartPlotData_startPlot_data',
       'G__typename',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      channelRate,
+      r'GStartPlotData_startPlot_data',
+      'channelRate',
     );
     BuiltValueNullFieldError.checkNotNull(
       channelUnits,
@@ -735,6 +756,7 @@ class _$GStartPlotData_startPlot_data extends GStartPlotData_startPlot_data {
     if (identical(other, this)) return true;
     return other is GStartPlotData_startPlot_data &&
         G__typename == other.G__typename &&
+        channelRate == other.channelRate &&
         channelUnits == other.channelUnits &&
         channelStatus == other.channelStatus &&
         channelData == other.channelData;
@@ -744,6 +766,7 @@ class _$GStartPlotData_startPlot_data extends GStartPlotData_startPlot_data {
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, channelRate.hashCode);
     _$hash = $jc(_$hash, channelUnits.hashCode);
     _$hash = $jc(_$hash, channelStatus.hashCode);
     _$hash = $jc(_$hash, channelData.hashCode);
@@ -755,6 +778,7 @@ class _$GStartPlotData_startPlot_data extends GStartPlotData_startPlot_data {
   String toString() {
     return (newBuiltValueToStringHelper(r'GStartPlotData_startPlot_data')
           ..add('G__typename', G__typename)
+          ..add('channelRate', channelRate)
           ..add('channelUnits', channelUnits)
           ..add('channelStatus', channelStatus)
           ..add('channelData', channelData))
@@ -773,6 +797,10 @@ class GStartPlotData_startPlot_dataBuilder
   String? _G__typename;
   String? get G__typename => _$this._G__typename;
   set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _channelRate;
+  String? get channelRate => _$this._channelRate;
+  set channelRate(String? channelRate) => _$this._channelRate = channelRate;
 
   String? _channelUnits;
   String? get channelUnits => _$this._channelUnits;
@@ -799,6 +827,7 @@ class GStartPlotData_startPlot_dataBuilder
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
+      _channelRate = $v.channelRate;
       _channelUnits = $v.channelUnits;
       _channelStatus = $v.channelStatus;
       _channelData = $v.channelData.toBuilder();
@@ -831,6 +860,11 @@ class GStartPlotData_startPlot_dataBuilder
               G__typename,
               r'GStartPlotData_startPlot_data',
               'G__typename',
+            ),
+            channelRate: BuiltValueNullFieldError.checkNotNull(
+              channelRate,
+              r'GStartPlotData_startPlot_data',
+              'channelRate',
             ),
             channelUnits: BuiltValueNullFieldError.checkNotNull(
               channelUnits,

--- a/lib/src/service/acsys/schema/__generated__/users_last_config.data.gql.dart
+++ b/lib/src/service/acsys/schema/__generated__/users_last_config.data.gql.dart
@@ -53,7 +53,7 @@ abstract class GUsersLastConfigData_usersLastConfiguration
 
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  int get configurationId;
+  int? get configurationId;
   String get configurationName;
   BuiltList<GUsersLastConfigData_usersLastConfiguration_channels> get channels;
   double? get xMin;

--- a/lib/src/service/acsys/schema/__generated__/users_last_config.data.gql.g.dart
+++ b/lib/src/service/acsys/schema/__generated__/users_last_config.data.gql.g.dart
@@ -118,11 +118,6 @@ class _$GUsersLastConfigData_usersLastConfigurationSerializer
         object.G__typename,
         specifiedType: const FullType(String),
       ),
-      'configurationId',
-      serializers.serialize(
-        object.configurationId,
-        specifiedType: const FullType(int),
-      ),
       'configurationName',
       serializers.serialize(
         object.configurationName,
@@ -162,6 +157,12 @@ class _$GUsersLastConfigData_usersLastConfigurationSerializer
       ),
     ];
     Object? value;
+    value = object.configurationId;
+    if (value != null) {
+      result
+        ..add('configurationId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     value = object.xMin;
     if (value != null) {
       result
@@ -247,11 +248,8 @@ class _$GUsersLastConfigData_usersLastConfigurationSerializer
           break;
         case 'configurationId':
           result.configurationId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(int),
-                  )!
-                  as int;
+              serializers.deserialize(value, specifiedType: const FullType(int))
+                  as int?;
           break;
         case 'configurationName':
           result.configurationName =
@@ -610,7 +608,7 @@ class _$GUsersLastConfigData_usersLastConfiguration
   @override
   final String G__typename;
   @override
-  final int configurationId;
+  final int? configurationId;
   @override
   final String configurationName;
   @override
@@ -652,7 +650,7 @@ class _$GUsersLastConfigData_usersLastConfiguration
 
   _$GUsersLastConfigData_usersLastConfiguration._({
     required this.G__typename,
-    required this.configurationId,
+    this.configurationId,
     required this.configurationName,
     required this.channels,
     this.xMin,
@@ -673,11 +671,6 @@ class _$GUsersLastConfigData_usersLastConfiguration
       G__typename,
       r'GUsersLastConfigData_usersLastConfiguration',
       'G__typename',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      configurationId,
-      r'GUsersLastConfigData_usersLastConfiguration',
-      'configurationId',
     );
     BuiltValueNullFieldError.checkNotNull(
       configurationName,
@@ -940,11 +933,7 @@ class GUsersLastConfigData_usersLastConfigurationBuilder
               r'GUsersLastConfigData_usersLastConfiguration',
               'G__typename',
             ),
-            configurationId: BuiltValueNullFieldError.checkNotNull(
-              configurationId,
-              r'GUsersLastConfigData_usersLastConfiguration',
-              'configurationId',
-            ),
+            configurationId: configurationId,
             configurationName: BuiltValueNullFieldError.checkNotNull(
               configurationName,
               r'GUsersLastConfigData_usersLastConfiguration',

--- a/lib/src/service/acsys/schema/start_plot.graphql
+++ b/lib/src/service/acsys/schema/start_plot.graphql
@@ -3,6 +3,7 @@ subscription StartPlot($drfList: [String!]!, $xMin: Float, $xMax: Float, $window
     plotId
     timestamp
     data {
+      channelRate
       channelUnits
       channelStatus
       channelData {

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1079,7 +1079,10 @@ final class ACSysService implements ACSysServiceAPI {
               data.plotConfiguration
                   .map(
                     (e) => PlotConfigurationListing(
-                      configurationId: PlotConfigId._fromInt(e.configurationId),
+                      configurationId:
+                          e.configurationId != null
+                              ? PlotConfigId._fromInt(e.configurationId!)
+                              : null,
                       configurationName: e.configurationName,
                     ),
                   )
@@ -1108,7 +1111,10 @@ final class ACSysService implements ACSysServiceAPI {
         final e = data.usersLastConfiguration!;
 
         return PlotConfigurationSnapshot(
-          configurationId: PlotConfigId._fromInt(e.configurationId),
+          configurationId:
+              e.configurationId != null
+                  ? PlotConfigId._fromInt(e.configurationId!)
+                  : null,
           configurationName: e.configurationName,
           channels: Map.fromEntries(
             e.channels.map(
@@ -1163,7 +1169,10 @@ final class ACSysService implements ACSysServiceAPI {
               data.plotConfiguration
                   .map(
                     (e) => PlotConfigurationSnapshot(
-                      configurationId: PlotConfigId._fromInt(e.configurationId),
+                      configurationId:
+                          e.configurationId != null
+                              ? PlotConfigId._fromInt(e.configurationId!)
+                              : null,
                       configurationName: e.configurationName,
                       channels: Map.fromEntries(
                         e.channels.map(
@@ -1296,7 +1305,7 @@ extension on GStartPlotData_startPlot_data {
       PlotChannelData(
         name: req.vars.drfList[idx],
         units: channelUnits,
-        rate: "Rate not supported by API yet.",
+        rate: channelRate,
         status: channelStatus,
         points: [...channelData.map((e) => PlotPoint(t: e.t, x: e.x, y: e.y))],
       );


### PR DESCRIPTION
This pull request adds API support for the plot's `channelRate` field. We still need to compute the value, but the Flutter library will automatically reflect whatever value eventually gets sent.