### PR TITLE
Add OpenTelemetry tracing support and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,67 @@ code. The command to do this is:
 ```shell
 $ dart run build_runner build --delete-conflicting-outputs
 ```
+
+## Telemetry/Tracing (OpenTelemetry)
+
+OpenTelemetry tracing is enabled by default (opt-out) for all apps using this package's entrypoints (`runFermiApp`, `runFermiRouterApp`).
+
+- Traces are exported to the console by default (see `ConsoleExporter`).
+  - In the future we will need a custom exporter for GraphQL. Good news is that otel is gRPC by default.
+- You can override the exporter by calling `initOpenTelemetry(exporter: ...)` before app startup.
+- Manual instrumentation is available for custom spans and events.
+
+### Manual Instrumentation Example
+
+```dart
+import 'package:flutter_controls_core/flutter_controls_core.dart';
+
+final span = startSpan('operation', attributes: {'key': 'value'});
+try {
+  // ... your code ...
+  addEvent(span, 'eventName', attributes: {'foo': 42});
+} finally {
+  endSpan(span);
+}
+```
+
+Or use the convenience wrappers for automatic span management:
+
+```dart
+runWithSpan('operation', (span) {
+  // ... your code ...
+});
+
+await runWithSpanAsync('asyncOp', (span) async {
+  // ... your async code ...
+});
+```
+
+### Dependency Injection and Testing
+
+Use the `AppTracer` interface and the `appTracer` instance for testable code:
+
+```dart
+class MyService {
+  final AppTracer tracer;
+  MyService(this.tracer);
+  void doWork() {
+    tracer.runWithSpan('work', (span) {
+      // ...
+    });
+  }
+}
+```
+
+In tests, inject a mock tracer if needed.
+
+### Opting Out
+
+To disable tracing, you can override `initOpenTelemetry` with a no-op exporter or skip calling it (not recommended for most apps).
+
+For more details, see the API documentation in `lib/src/otel_tracing.dart`.
+
+### TODO
+
+- Add metrics
+- Add logging

--- a/lib/flutter_controls_core.dart
+++ b/lib/flutter_controls_core.dart
@@ -5,7 +5,9 @@ import "package:flutter/material.dart";
 import "src/auth_widget.dart";
 import 'package:go_router/go_router.dart';
 import 'src/app_scaffold.dart';
+import 'src/otel_tracing.dart';
 
+export 'package:opentelemetry/api.dart' show Span;
 export 'src/status.dart';
 export 'src/device_values.dart';
 export 'src/app_scaffold.dart';
@@ -14,12 +16,13 @@ export 'src/auth_widget.dart' show ScopeList, AuthInfo, AuthService;
 export 'src/service/acsys_service.dart';
 
 export 'package:openid_client/openid_client.dart' show Credential, UserInfo;
+export 'src/otel_tracing.dart';
 
 /// Entry point for Fermilab applications
 ///
-/// This function intializes the environment for the application as well as
+/// This function initializes the environment for the application as well as
 /// creating a widget [Scaffold] that uses a standard color theme. It also
-/// handles authentication with KeyCloak.
+/// handles authentication with KeyCloak and sets up OpenTelemetry tracing.
 ///
 /// - [appWidget] is the main widget that holds the body of the application.
 /// - [authInfo] is an optional parameter which holds configuration information
@@ -27,11 +30,11 @@ export 'package:openid_client/openid_client.dart' show Credential, UserInfo;
 ///   parameter is `null`, no credentials will be used (and most, if not all,
 ///   services won't let your application make modifications to the control
 ///   system.)
-
 Future<void> runFermiApp({
   required Widget appWidget,
   AuthInfo? authInfo,
 }) async {
+  await initOpenTelemetry();
   if (authInfo != null) {
     await initAuth(
       authInfo.realm,
@@ -48,6 +51,7 @@ Future<void> runFermiRouterApp({
   AuthInfo? authInfo,
   required String title,
 }) async {
+  await initOpenTelemetry();
   if (authInfo != null) {
     await initAuth(
       authInfo.realm,

--- a/lib/src/otel_tracing.dart
+++ b/lib/src/otel_tracing.dart
@@ -1,0 +1,217 @@
+import 'package:opentelemetry/api.dart' as otel;
+import 'package:opentelemetry/sdk.dart'
+    show TracerProviderBase, SimpleSpanProcessor, ConsoleExporter, SpanExporter;
+import 'package:opentelemetry/api.dart'
+    show registerGlobalTracerProvider, globalTracerProvider, Attribute;
+
+/// OpenTelemetry singleton tracer for manual instrumentation
+late final otel.Tracer otelTracer;
+
+/// More idiomatic Dart 3+ pattern matching for attribute conversion
+Attribute _toAttribute(String key, Object? value) => switch (value) {
+  String v => Attribute.fromString(key, v),
+  bool v => Attribute.fromBoolean(key, v),
+  double v => Attribute.fromDouble(key, v),
+  int v => Attribute.fromInt(key, v),
+  List<String> v => Attribute.fromStringList(key, v),
+  List<bool> v => Attribute.fromBooleanList(key, v),
+  List<double> v => Attribute.fromDoubleList(key, v),
+  List<int> v => Attribute.fromIntList(key, v),
+  _ => Attribute.fromString(key, value.toString()),
+};
+
+/// Initializes OpenTelemetry auto-instrumentation and tracer provider.
+/// Call this early in your app (e.g., in main or before runFermiApp).
+Future<void> initOpenTelemetry({
+  String serviceName = 'flutter_controls_core',
+  SpanExporter? exporter,
+}) async {
+  final tracerProvider = TracerProviderBase(
+    processors: [SimpleSpanProcessor(exporter ?? ConsoleExporter())],
+  );
+  registerGlobalTracerProvider(tracerProvider);
+  otelTracer = globalTracerProvider.getTracer(serviceName);
+}
+
+/// Start a manual span. Returns the span, which you must end.
+otel.Span startSpan(String name, {Map<String, Object?>? attributes}) {
+  final span = otelTracer.startSpan(name);
+  if (attributes != null) {
+    for (final entry in attributes.entries) {
+      span.setAttribute(_toAttribute(entry.key, entry.value));
+    }
+  }
+  return span;
+}
+
+/// Add an event to a span (must be provided by the caller).
+void addEvent(otel.Span span, String name, {Map<String, Object?>? attributes}) {
+  final attrList =
+      attributes?.entries.map((e) => _toAttribute(e.key, e.value)).toList() ??
+      const [];
+  span.addEvent(name, attributes: attrList);
+}
+
+/// End the provided span.
+void endSpan(otel.Span span) {
+  span.end();
+}
+
+/// Starts a span, executes a function, and ends the span automatically.
+///
+/// This is recommended for reliability: the span will always be ended, even if an exception occurs.
+///
+/// Example usage:
+/// ```dart
+/// runWithSpan('myOperation', (span) {
+///   // Do work
+/// });
+/// ```
+R runWithSpan<R>(
+  String name,
+  R Function(otel.Span span) fn, {
+  Map<String, Object?>? attributes,
+}) {
+  final span = startSpan(name, attributes: attributes);
+  try {
+    return fn(span);
+  } finally {
+    endSpan(span);
+  }
+}
+
+/// Starts a span, executes an async function, and ends the span automatically.
+///
+/// Example usage:
+/// ```dart
+/// await runWithSpanAsync('myAsyncOperation', (span) async {
+///   // Do async work
+/// });
+/// ```
+Future<R> runWithSpanAsync<R>(
+  String name,
+  Future<R> Function(otel.Span span) fn, {
+  Map<String, Object?>? attributes,
+}) async {
+  final span = startSpan(name, attributes: attributes);
+  try {
+    return await fn(span);
+  } finally {
+    endSpan(span);
+  }
+}
+
+/// Abstract tracer interface for testability and flexibility.
+abstract class AppTracer {
+  otel.Span startSpan(String name, {Map<String, Object?>? attributes});
+  void addEvent(
+    otel.Span span,
+    String name, {
+    Map<String, Object?>? attributes,
+  });
+  void endSpan(otel.Span span);
+  R runWithSpan<R>(
+    String name,
+    R Function(otel.Span span) fn, {
+    Map<String, Object?>? attributes,
+  });
+  Future<R> runWithSpanAsync<R>(
+    String name,
+    Future<R> Function(otel.Span span) fn, {
+    Map<String, Object?>? attributes,
+  });
+}
+
+/// Default implementation using the global otelTracer.
+class GlobalAppTracer implements AppTracer {
+  @override
+  otel.Span startSpan(String name, {Map<String, Object?>? attributes}) =>
+      startSpan(name, attributes: attributes);
+
+  @override
+  void addEvent(
+    otel.Span span,
+    String name, {
+    Map<String, Object?>? attributes,
+  }) => addEvent(span, name, attributes: attributes);
+
+  @override
+  void endSpan(otel.Span span) => endSpan(span);
+
+  @override
+  R runWithSpan<R>(
+    String name,
+    R Function(otel.Span span) fn, {
+    Map<String, Object?>? attributes,
+  }) => runWithSpan(name, fn, attributes: attributes);
+
+  @override
+  Future<R> runWithSpanAsync<R>(
+    String name,
+    Future<R> Function(otel.Span span) fn, {
+    Map<String, Object?>? attributes,
+  }) => runWithSpanAsync(name, fn, attributes: attributes);
+}
+
+/// The default tracer instance for use in most apps (opt-out global).
+final AppTracer appTracer = GlobalAppTracer();
+
+/// ---
+/// # OpenTelemetry Usage Guidance
+///
+/// ## Overview
+///
+/// OpenTelemetry tracing is enabled by default (opt-out) for all apps using this package's entrypoints.
+///
+/// - Auto-instrumentation is initialized automatically in `runFermiApp` and `runFermiRouterApp`.
+/// - All spans are exported to the console by default (see `ConsoleExporter`).
+/// - You can override the exporter by calling `initOpenTelemetry(exporter: ...)` before app startup.
+///
+/// ## Manual Instrumentation
+///
+/// Use the helpers below for manual spans and events:
+///
+/// ```dart
+/// final span = startSpan('operation', attributes: {'key': 'value'});
+/// try {
+///   // ... your code ...
+///   addEvent(span, 'eventName', attributes: {'foo': 42});
+/// } finally {
+///   endSpan(span);
+/// }
+/// ```
+///
+/// Or use the convenience wrappers for automatic span management:
+///
+/// ```dart
+/// runWithSpan('operation', (span) {
+///   // ... your code ...
+/// });
+///
+/// await runWithSpanAsync('asyncOp', (span) async {
+///   // ... your async code ...
+/// });
+/// ```
+///
+/// ## Dependency Injection and Testing
+///
+/// Use the `AppTracer` interface and the `appTracer` instance for testable code:
+///
+/// ```dart
+/// class MyService {
+///   final AppTracer tracer;
+///   MyService(this.tracer);
+///   void doWork() {
+///     tracer.runWithSpan('work', (span) {
+///       // ...
+///     });
+///   }
+/// }
+/// ```
+///
+/// In tests, inject a mock tracer if needed.
+///
+/// ## Opting Out
+///
+/// To disable tracing, you can override `initOpenTelemetry` with a no-op exporter or skip calling it (not recommended for most apps).
+/// ---

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
 
     openid_client: ^0.4.8
     url_launcher: ^6.2.1
+    opentelemetry: ^0.18.10
 
 dev_dependencies:
     flutter_test:


### PR DESCRIPTION
- Implement OpenTelemetry tracing in `runFermiApp` and `runFermiRouterApp`.
- Create `otel_tracing.dart` for OpenTelemetry initialization and manual instrumentation.
- Update README with telemetry/tracing details and usage examples.
- Add OpenTelemetry dependency in pubspec.yaml.

This is just to get this included. In the future we need to add metrics and logging which are separate concepts from tracing.

Also, this only outputs to the browser console. We'll want to change that to go to a GraphQL endpoint. The setup on the Prometheus side seems to be straightforward and is gRPC by default. So, we'll need to figure out how to map that service into GraphQL to get this traces to our observability platform.