### PR TITLE
feat: :sparkles: Make the font definition explicit

### DIFF
--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -13,13 +13,17 @@ import 'auth_widget.dart';
 final class _GlobalAppTheme {
   _GlobalAppTheme._();
 
+  static const String _fontFamily = 'Roboto';
+
   static ThemeData lightTheme = ThemeData(
     useMaterial3: true,
     colorScheme: lightColorScheme,
+    fontFamily: _fontFamily,
   );
   static ThemeData darkTheme = ThemeData(
     useMaterial3: true,
     colorScheme: darkColorScheme,
+    fontFamily: _fontFamily,
   );
 }
 


### PR DESCRIPTION
This requests the Roboto font, which I hope references the local fonts/Roboto*.ttf file.