### PR TITLE
:recycle: make `FaasService` public

### DIFF
--- a/lib/src/service/faas_service.dart
+++ b/lib/src/service/faas_service.dart
@@ -14,7 +14,7 @@ abstract interface class FaasServiceAPI {
   Future<Int64> unixToClinks(Int64 time);
 }
 
-final class _FaasService implements FaasServiceAPI {
+final class FaasService implements FaasServiceAPI {
   final Client _q;
 
   static Map<String, String> _buildAuthHeader(String? jwt) =>
@@ -23,7 +23,7 @@ final class _FaasService implements FaasServiceAPI {
   // Constructor. This creates the HTTP link needed to communicate with our
   // GraphQL endpoint.
 
-  _FaasService({String? jwt})
+  FaasService({String? jwt})
     : _q = Client(
         link: HttpLink(
           "https://acsys-proxy.fnal.gov:8001/faas",
@@ -130,7 +130,7 @@ final class FaasProvider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => _FaasProviderIW(
-    service: service ?? _FaasService(jwt: AuthService.getJwt(context)),
+    service: service ?? FaasService(jwt: AuthService.getJwt(context)),
     child: child,
   );
 }


### PR DESCRIPTION
We are planning on extracting the GraphQL objects into their own Dart packages so this needs to be public anyway.