### PR TITLE
:bug: can't cast `double` to `int`

### DIFF
--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1078,7 +1078,7 @@ final class ACSysService implements ACSysServiceAPI {
   }
 
   static DateTime fromFloatTs(double ts) =>
-      DateTime.fromMicrosecondsSinceEpoch((ts * 1000000.0) as int);
+      DateTime.fromMicrosecondsSinceEpoch((ts * 1000000.0).toInt());
 
   // Convert the incoming GraphQL messages into `Reading` objects.
 


### PR DESCRIPTION
The code that no longer works was added Oct, 2025. So recent versions of Dart must have broke it.

It looks like the `as` keyword now only works with class hierarchies and doesn't perform typecasts for numeric types.