### PR TITLE
Minor update

### DIFF
--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -32,39 +32,110 @@ final class _GlobalAppTheme {
 Widget buildAuthHeader(
   final IconData icon,
   final String account,
-  final (String, void Function())? buttonInfo,
-) => Row(
-  mainAxisAlignment: MainAxisAlignment.start,
-  crossAxisAlignment: CrossAxisAlignment.center,
-  children: <Widget>[
-    Expanded(
-      child: Center(
+  final (String, void Function())? buttonInfo, [
+  final Widget? subtitle,
+]) => Padding(
+  padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 8.0),
+  child: Row(
+    children: [
+      Expanded(
+        flex: 3,
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
+          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
-            Icon(icon, size: 40.0),
-            SizedBox(height: 4.0), // Spacer
-            Text(account),
+            Icon(icon, size: 48.0),
+            const SizedBox(height: 8.0),
+            Text(
+              account,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            if (subtitle != null) subtitle,
           ],
         ),
       ),
-    ),
-    if (buttonInfo != null)
-      Expanded(
-        child: Center(
+      if (buttonInfo != null) ...[
+        const SizedBox(height: 12.0),
+        Expanded(
+          flex: 2,
           child: ElevatedButton(
             onPressed: buttonInfo.$2,
             child: Text(buttonInfo.$1),
           ),
         ),
-      ),
-  ],
+      ],
+    ],
+  ),
 );
+
+Widget? _buildMissingRolesWarning(BuildContext context, Set<String> needed) {
+  final missing =
+      needed.where((role) => !AuthService.inRole(context, role)).toList();
+
+  if (missing.isEmpty) return null;
+
+  final colorScheme = Theme.of(context).colorScheme;
+
+  return Column(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      const SizedBox(height: 12.0),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.warning_amber_rounded,
+            color: colorScheme.error,
+            size: 16.0,
+          ),
+          const SizedBox(width: 4.0),
+          Text(
+            "Missing Roles",
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: colorScheme.error,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+      const SizedBox(height: 8.0),
+      Wrap(
+        spacing: 4.0,
+        runSpacing: 4.0,
+        alignment: WrapAlignment.center,
+        children:
+            missing
+                .map(
+                  (role) => Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8.0,
+                      vertical: 2.0,
+                    ),
+                    decoration: BoxDecoration(
+                      color: colorScheme.errorContainer,
+                      borderRadius: BorderRadius.circular(4.0),
+                    ),
+                    child: Text(
+                      role,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onErrorContainer,
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+      ),
+    ],
+  );
+}
 
 // Private widget used to display content in the side, drawer menu's header.
 
 final class _DrawerHeader extends StatelessWidget {
+  final Set<String> neededRoles;
+
+  const _DrawerHeader({this.neededRoles = const {}});
+
   @override
   Widget build(BuildContext context) {
     final UserInfo? userInfo = AuthService.getUserInfo(context);
@@ -89,6 +160,7 @@ final class _DrawerHeader extends StatelessWidget {
         Icons.account_circle,
         user.name ?? "UNKNOWN",
         ("Logout", () => AuthService.requestLogout(context)),
+        _buildMissingRolesWarning(context, neededRoles),
       ),
     };
 
@@ -98,8 +170,9 @@ final class _DrawerHeader extends StatelessWidget {
 
 final class _Drawer extends StatelessWidget {
   final Widget? content;
+  final Set<String> neededRoles;
 
-  const _Drawer(this.content);
+  const _Drawer(this.content, this.neededRoles);
 
   @override
   Widget build(BuildContext context) {
@@ -110,7 +183,7 @@ final class _Drawer extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: [
-            _DrawerHeader(),
+            _DrawerHeader(neededRoles: neededRoles),
             Divider(),
             Expanded(
               child: SingleChildScrollView(
@@ -199,7 +272,9 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
   /// [appBar] will be displayed as the application's title bar.
   final PreferredSizeWidget? appBar;
 
-  const StandardApp({
+  final Set<String> _neededRoles;
+
+  StandardApp({
     required this.title,
     T? model,
     this.appBar,
@@ -207,8 +282,10 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
     this.drawerContent,
     this.floatingActionButton,
     this.providers = const [],
+    List<String>? neededRoles,
     super.key,
-  }) : _model = model;
+  }) : _model = model,
+       _neededRoles = neededRoles?.toSet() ?? {};
 
   /// Returns the model shared by the whole application.
   ///
@@ -225,7 +302,7 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
       Scaffold(
         appBar: appBar,
         body: body,
-        drawer: _Drawer(drawerContent),
+        drawer: _Drawer(drawerContent, _neededRoles),
         floatingActionButton: floatingActionButton,
       ),
       (w, p) => p(child: w),

--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -32,9 +32,9 @@ final class _GlobalAppTheme {
 Widget buildAuthHeader(
   final IconData icon,
   final String account,
-  final (String, void Function())? buttonInfo, [
+  final (String, void Function())? buttonInfo,
   final Widget? subtitle,
-]) => Padding(
+) => Padding(
   padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 8.0),
   child: Row(
     children: [
@@ -140,7 +140,10 @@ final class _DrawerHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final UserInfo? userInfo = AuthService.getUserInfo(context);
 
-    final content = switch ((userInfo, AuthService.authRequired)) {
+    final content = switch ((
+      userInfo,
+      AuthService.authRequired || neededRoles.isNotEmpty,
+    )) {
       // For this case, the application didn't set up authentication parameters
       // so it plans to run with no privilieges. If the application tries to
       // use a service that needs authorization, the service will return an
@@ -149,12 +152,15 @@ final class _DrawerHeader extends StatelessWidget {
         Icons.no_accounts_sharp,
         "No login required",
         null,
+        null,
       ),
 
-      (null, true) => buildAuthHeader(Icons.no_accounts_sharp, "Unauthorized", (
-        "Login",
-        () => AuthService.requestLogin(context),
-      )),
+      (null, true) => buildAuthHeader(
+        Icons.no_accounts_sharp,
+        "Unauthorized",
+        ("Login", () => AuthService.requestLogin(context)),
+        _buildMissingRolesWarning(context, neededRoles),
+      ),
 
       (UserInfo user, true) => buildAuthHeader(
         Icons.account_circle,

--- a/lib/src/device_values.dart
+++ b/lib/src/device_values.dart
@@ -79,7 +79,7 @@ sealed class DeviceValue {
 /// data buffers (i.e. image data.)
 
 final class DevRaw extends DeviceValue {
-  final List<int> value;
+  final Uint8List value;
 
   const DevRaw(this.value);
 }
@@ -145,7 +145,7 @@ extension TextToDeviceValue on String {
   DeviceValue toDevVal() => DevText(this);
 }
 
-extension RawToDeviceValue on List<int> {
+extension RawToDeviceValue on Uint8List {
   DeviceValue toDevVal() => DevRaw(this);
 }
 
@@ -185,7 +185,7 @@ extension FromDevValToText on DeviceValue {
 }
 
 extension FromDevValToRaw on DeviceValue {
-  List<int>? toRaw() => switch (this) {
+  Uint8List? toRaw() => switch (this) {
     DevRaw(value: var value) => value,
     _ => null,
   };

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -793,11 +793,8 @@ final class ACSysService implements ACSysServiceAPI {
   final Client _qAlarms;
   final Client _sAlarms;
 
-  static Map<String, String> _buildAuthHeader(String? jwt) {
-    dev.log("building header with jwt: $jwt");
-
-    return jwt != null ? {"Authorization": "Bearer $jwt"} : {};
-  }
+  static Map<String, String> _buildAuthHeader(String? jwt) =>
+      jwt != null ? {"Authorization": "Bearer $jwt"} : {};
 
   // Constructor. This creates the HTTP links needed to communicate with our
   // GraphQL endpoints.

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -793,8 +793,11 @@ final class ACSysService implements ACSysServiceAPI {
   final Client _qAlarms;
   final Client _sAlarms;
 
-  static Map<String, String> _buildAuthHeader(String? jwt) =>
-      jwt != null ? {"Authorization": "Bearer $jwt"} : {};
+  static Map<String, String> _buildAuthHeader(String? jwt) {
+    dev.log("building header with jwt: $jwt");
+
+    return jwt != null ? {"Authorization": "Bearer $jwt"} : {};
+  }
 
   // Constructor. This creates the HTTP links needed to communicate with our
   // GraphQL endpoints.
@@ -821,6 +824,7 @@ final class ACSysService implements ACSysServiceAPI {
            Client(
              link: WebSocketLink(
                null,
+               initialPayload: _buildAuthHeader(jwt),
                channelGenerator:
                    () => WebSocketChannel.connect(
                      Uri(
@@ -858,6 +862,7 @@ final class ACSysService implements ACSysServiceAPI {
            Client(
              link: WebSocketLink(
                null,
+               initialPayload: _buildAuthHeader(jwt),
                channelGenerator:
                    () => WebSocketChannel.connect(
                      Uri(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.3.1
+version: 0.4.0
 publish_to: none
 
 environment:

--- a/test/device_value_test.dart
+++ b/test/device_value_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 import 'package:flutter_controls_core/flutter_controls_core.dart';
 
@@ -9,7 +11,7 @@ DeviceValue _makeText(String s) => DevText(s);
 
 DeviceValue _makeTextArray(List<String> s) => DevTextArray(s);
 
-DeviceValue _makeRaw(List<int> v) => DevRaw(v);
+DeviceValue _makeRaw(Uint8List v) => DevRaw(v);
 
 void main() {
   // This test verifies the equality operator is working for `DeviceValue`
@@ -21,42 +23,76 @@ void main() {
     expect(_makeScalar(1.0), equals(_makeScalar(1.0)));
     expect(_makeScalar(2.0), isNot(equals(_makeScalar(1.0))));
 
-    expect(_makeRaw([]), isNot(equals(_makeScalar(1.0))));
-    expect(_makeRaw([]), equals(_makeRaw([])));
-    expect(_makeRaw([]), isNot(equals(_makeText("Hi"))));
-    expect(_makeRaw([1, 2, 3]), equals(_makeRaw([1, 2, 3])));
-    expect(_makeRaw([1, 2, 3]), isNot(equals(_makeRaw([0, 2, 3]))));
+    expect(_makeRaw(Uint8List.fromList([])), isNot(equals(_makeScalar(1.0))));
+    expect(
+      _makeRaw(Uint8List.fromList([])),
+      equals(_makeRaw(Uint8List.fromList([]))),
+    );
+    expect(_makeRaw(Uint8List.fromList([])), isNot(equals(_makeText("Hi"))));
+    expect(
+      _makeRaw(Uint8List.fromList([1, 2, 3])),
+      equals(_makeRaw(Uint8List.fromList([1, 2, 3]))),
+    );
+    expect(
+      _makeRaw(Uint8List.fromList([1, 2, 3])),
+      isNot(equals(_makeRaw(Uint8List.fromList([0, 2, 3])))),
+    );
 
     expect(_makeText("Hello"), isNot(equals(_makeScalar(1.0))));
-    expect(_makeText("hello"), isNot(equals(_makeRaw([]))));
+    expect(_makeText("hello"), isNot(equals(_makeRaw(Uint8List.fromList([])))));
     expect(_makeText("Hello"), equals(_makeText("Hello")));
     expect(_makeText("Hello"), isNot(equals(_makeText("Hi"))));
 
     expect(_makeTextArray(["Hello", "there"]), isNot(equals(_makeScalar(1.0))));
-    expect(_makeTextArray(["Hello", "there"]), isNot(equals(_makeRaw([]))));
+    expect(
+      _makeTextArray(["Hello", "there"]),
+      isNot(equals(_makeRaw(Uint8List.fromList([])))),
+    );
     expect(_makeTextArray(["Hello", "there"]), isNot(equals(_makeText("Hi"))));
-    expect(_makeTextArray(["Hello", "there"]),
-        equals(_makeTextArray(["Hello", "there"])));
-    expect(_makeTextArray(["Hello", "there"]),
-        isNot(equals(_makeTextArray(["Hi", "there"]))));
+    expect(
+      _makeTextArray(["Hello", "there"]),
+      equals(_makeTextArray(["Hello", "there"])),
+    );
+    expect(
+      _makeTextArray(["Hello", "there"]),
+      isNot(equals(_makeTextArray(["Hi", "there"]))),
+    );
 
     expect(_makeScalarArray([1.0, 2.0, 3.0]), isNot(equals(_makeScalar(1.0))));
-    expect(_makeScalarArray([1.0, 2.0, 3.0]), isNot(equals(_makeRaw([]))));
+    expect(
+      _makeScalarArray([1.0, 2.0, 3.0]),
+      isNot(equals(_makeRaw(Uint8List.fromList([])))),
+    );
     expect(_makeScalarArray([1.0, 2.0, 3.0]), isNot(equals(_makeText("Hi"))));
-    expect(_makeScalarArray([1.0, 2.0, 3.0]),
-        isNot(equals(_makeTextArray(["Hello", "there"]))));
-    expect(_makeScalarArray([1.0, 2.0, 3.0]),
-        equals(_makeScalarArray([1.0, 2.0, 3.0])));
-    expect(_makeScalarArray([1.0, 2.0, 3.0]),
-        isNot(equals(_makeScalarArray([1.0, 3.0]))));
+    expect(
+      _makeScalarArray([1.0, 2.0, 3.0]),
+      isNot(equals(_makeTextArray(["Hello", "there"]))),
+    );
+    expect(
+      _makeScalarArray([1.0, 2.0, 3.0]),
+      equals(_makeScalarArray([1.0, 2.0, 3.0])),
+    );
+    expect(
+      _makeScalarArray([1.0, 2.0, 3.0]),
+      isNot(equals(_makeScalarArray([1.0, 3.0]))),
+    );
   });
 
   test("Test device value conversions", () {
     // Make sure the DeviceValue types all pass through unchanged.
 
-    expect(_makeRaw([]).toDevVal(), equals(_makeRaw([])));
-    expect(_makeRaw([1, 2]).toDevVal(), equals(_makeRaw([1, 2])));
-    expect([1, 2].toDevVal(), equals(_makeRaw([1, 2])));
+    expect(
+      _makeRaw(Uint8List.fromList([])).toDevVal(),
+      equals(_makeRaw(Uint8List.fromList([]))),
+    );
+    expect(
+      _makeRaw(Uint8List.fromList([1, 2])).toDevVal(),
+      equals(_makeRaw(Uint8List.fromList([1, 2]))),
+    );
+    expect(
+      Uint8List.fromList([1, 2]).toDevVal(),
+      equals(_makeRaw(Uint8List.fromList([1, 2]))),
+    );
 
     expect(_makeScalar(1.0).toDevVal(), equals(_makeScalar(1.0)));
     expect(1.0.toDevVal(), equals(_makeScalar(1.0)));


### PR DESCRIPTION
- bump to v0.4.0
- When asking for raw device data, the data is now returned as a `Uint8List` type instead of `List<int>`. A `Uint8List` is a true block of memory containing 8-bit integers, whereas a `List<int>` is an array of 64-bit integers so it was *very* wasteful.
- Removed the `scopes` field from `AuthInfo`. `scopes` did not mean "roles".
- Added a parameter, `List<String>? neededRoles`, to the `StandardApp` constructor. The drawer uses this information to notify the user which roles that are missing.
- Added JWT to subscriptions