### PR TITLE
Preserve ACSys StatusReply values and fix status decoding

### DIFF
--- a/lib/src/device_values.dart
+++ b/lib/src/device_values.dart
@@ -28,6 +28,7 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'status.dart';
 
 /// Use this type to indicate any device type is allowed.
 ///
@@ -55,6 +56,8 @@ sealed class DeviceValue {
         return listEquals(v, o);
       case ((DevTimeSeries(values: var v), DevTimeSeries(values: var o))):
         return listEquals(v, o);
+      case ((DevStatusCode(status: var v), DevStatusCode(status: var o))):
+        return v == o;
       default:
         return false;
     }
@@ -68,7 +71,17 @@ sealed class DeviceValue {
     DevScalarArray(value: var v) => v.hashCode,
     DevTextArray(value: var v) => v.hashCode,
     DevTimeSeries(values: var v) => v.hashCode,
+    DevStatusCode(status: var v) => v.hashCode,
   };
+}
+
+final class DevStatusCode extends DeviceValue {
+  final Status status;
+
+  const DevStatusCode(this.status);
+
+  @override
+  String toString() => "[${status.facility} ${status.error}]";
 }
 
 /// Represents a raw, byte array.
@@ -173,6 +186,13 @@ extension TimeSeriesToDeviceValue on List<(DateTime, double)> {
 extension FromDevValToDouble on DeviceValue {
   double? toDouble() => switch (this) {
     DevScalar(value: var value) => value,
+    _ => null,
+  };
+}
+
+extension FromDevValToStatus on DeviceValue {
+  Status? toStatus() => switch (this) {
+    DevStatusCode(status: var value) => value,
     _ => null,
   };
 }

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1545,6 +1545,8 @@ extension on GStartPlotData_startPlot_data_channelData_result {
 
 extension on GStreamDataData_acceleratorData_data_result {
   DeviceValue toDevValue() => switch (this) {
+    GStreamDataData_acceleratorData_data_result__asStatusReply val =>
+      DevStatusCode(Status.fromInt(val.status)),
     GStreamDataData_acceleratorData_data_result__asScalar val => DevScalar(
       val.scalarValue,
     ),
@@ -1561,6 +1563,8 @@ extension on GStreamDataData_acceleratorData_data_result {
 
 extension on GReadDevicesData_acceleratorData_data_result {
   DeviceValue toDevValue() => switch (this) {
+    GReadDevicesData_acceleratorData_data_result__asStatusReply val =>
+      DevStatusCode(Status.fromInt(val.status)),
     GReadDevicesData_acceleratorData_data_result__asScalar val => DevScalar(
       val.scalarValue,
     ),
@@ -1610,6 +1614,9 @@ extension on GStartPlotData_startPlot {
 
 extension on DeviceValue {
   GDevValueBuilder _toGDevValue() => switch (this) {
+    DevStatusCode() => throw ACSysGraphQLException(
+      "can't send DevStatusCode types",
+    ),
     DevRaw(value: var v) => GDevValueBuilder()..rawVal = ListBuilder(v),
     DevScalar(value: var v) => GDevValueBuilder()..scalarVal = v,
     DevScalarArray(value: var v) =>

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1614,8 +1614,8 @@ extension on GStartPlotData_startPlot {
 
 extension on DeviceValue {
   GDevValueBuilder _toGDevValue() => switch (this) {
-    DevStatusCode() => throw ACSysGraphQLException(
-      "can't send DevStatusCode types",
+    DevStatusCode() => throw ACSysInvArgException(
+      "DevStatusCode is a read-only status reply and is not writable",
     ),
     DevRaw(value: var v) => GDevValueBuilder()..rawVal = ListBuilder(v),
     DevScalar(value: var v) => GDevValueBuilder()..scalarVal = v,

--- a/lib/src/status.dart
+++ b/lib/src/status.dart
@@ -4,7 +4,7 @@ extension type Status._(int code) {
   const Status.fromInt(int value) : code = value;
 
   int get facility => code & 255;
-  int get error => code ~/ 256;
+  int get error => code >> 8;
 
   bool get success => error >= 0;
   bool get warning => error > 0;

--- a/test/device_value_test.dart
+++ b/test/device_value_test.dart
@@ -76,6 +76,15 @@ void main() {
       _makeScalarArray([1.0, 2.0, 3.0]),
       isNot(equals(_makeScalarArray([1.0, 3.0]))),
     );
+
+    expect(
+      DevStatusCode(Status.fromInt(273)),
+      equals(DevStatusCode(Status.fromInt(273))),
+    );
+    expect(
+      DevStatusCode(Status.fromInt(273)),
+      isNot(equals(DevStatusCode(Status.fromInt(-6143)))),
+    );
   });
 
   test("Test device value conversions", () {
@@ -103,5 +112,9 @@ void main() {
     expect("Hello".toDevVal(), equals(_makeText("Hello")));
 
     expect(_makeTextArray(["A"]).toDevVal(), equals(_makeTextArray(["A"])));
+    expect(
+      DevStatusCode(Status.fromInt(273)).toStatus(),
+      equals(Status.fromInt(273)),
+    );
   });
 }

--- a/test/status_test.dart
+++ b/test/status_test.dart
@@ -1,0 +1,24 @@
+import 'package:test/test.dart';
+import 'package:flutter_controls_core/flutter_controls_core.dart';
+
+void main() {
+  test('Status decodes positive facility and error values', () {
+    const status = Status.fromInt(273);
+
+    expect(status.facility, 17);
+    expect(status.error, 1);
+    expect(status.warning, isTrue);
+    expect(status.success, isTrue);
+    expect(status.fatal, isFalse);
+  });
+
+  test('Status preserves sign for negative error values', () {
+    const status = Status.fromInt(-6143);
+
+    expect(status.facility, 1);
+    expect(status.error, -24);
+    expect(status.warning, isFalse);
+    expect(status.success, isFalse);
+    expect(status.fatal, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

This change makes `flutter_controls_core` preserve ACSys GraphQL
`StatusReply` responses as typed device values instead of throwing a type
exception during read/stream conversion.

It also fixes signed status decoding so negative status codes produce the
correct `facility` / `error` split.

## Changes

- preserve GraphQL `StatusReply` as `DevStatusCode`
- handle status replies in ACSys read and stream conversion paths
- prevent `DevStatusCode` from being used as a writable setting value
- fix signed status decoding for negative codes
- add regression tests for status conversion, equality, and decoding

## Why

`StatusReply` is part of the ACSys schema and is a legitimate response
from DPM-backed reads. Treating it as a type error prevents clients from
inspecting and reacting to backend status conditions.

`dart-gql-acsys` already models status replies as typed values, so this
brings `flutter_controls_core` into line with the current ACSys contract.

## Validation

- `flutter test` passes in `flutter-controls-core`
- `flutter analyze` reports one pre-existing warning outside this patch
