### PR TITLE
Refactor `-core`

### DIFF
--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -246,7 +246,7 @@ class _GlobalStateProvider<T extends ChangeNotifier> extends InheritedWidget {
 /// [ChangeNotifier] so that changes to the global state can be recognized by
 /// the widgets using the state. Anytime the global state is changed, it must
 /// call [notifyListeners]. A way to ensure this is to define set properties
-/// on the type. To gain access to the global state, a widget can call
+/// on the type. to gain access to the global state, a widget can call
 /// [StandardApp.getGlobalState] in its [build] method.
 ///
 

--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -7,7 +7,8 @@ import 'package:flutter_controls_auth/flutter_controls_auth.dart';
 import 'package:go_router/go_router.dart';
 import 'fermi_theme.dart';
 
-// Our Fermi theme generated with - https://m3.material.io/theme-builder#/custom
+// Our Fermi theme generated with -
+// https://m3.material.io/theme-builder#/custom
 
 final class _GlobalAppTheme {
   _GlobalAppTheme._();
@@ -228,17 +229,17 @@ class _GlobalStateProvider<T extends ChangeNotifier> extends InheritedWidget {
 ///
 /// [StandardApp] provides developers quite a bit of common, standardized
 /// features that we expect from our applications. By using [StandardApp],
-/// you can build an application that follows look-and-feel of our applications
-/// and supports expected features:
+/// you can build an application that follows look-and-feel of our
+/// applications and supports expected features:
 ///
-/// * Uses our official light and dark mode themes to standardize on colors and
-///   fonts
-/// * Layout of top-level widgets will be consistent ([AppBar],
-///   [NavigationBar], [Drawer])
+/// * Uses our official light and dark mode themes to standardize on colors
+///   and fonts
+/// * Layout of top-level widgets will be consistent ([NavigationBar],
+///   [AppBar], [Drawer])
 /// * Authentication via KeyCloak
 /// * Opt-in for any of our GraphQL services
-/// * Global state support (for sharing data between the drawer and main body,
-///   for instance.)
+/// * Global state support (for sharing data between the drawer and main
+///   body, for instance.)
 
 final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
   final T? _model;
@@ -252,21 +253,22 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
 
   /// The main body of the drawer.
   ///
-  /// [StandardApp] creates a drawer on the left side. It automatically creates
-  /// a header and footer for the drawer. The main portion, however, can be
-  /// specied by the developer using this parameter.
+  /// [StandardApp] creates a drawer on the left side. It automatically
+  /// creates a header and footer for the drawer. The main portion, however,
+  /// can be specied by the developer using this parameter.
   final Widget? drawerContent;
 
   /// Creates [Widget]s that reside above the [Scaffold] widget.
   ///
-  /// This is a way to add [Widget]s that are located in the widget tree higher
-  /// than the [Scaffold] widget (i.e. the main, application framework.)
-  /// [providers] is a list of functions. Each function takes a [Widget] as a
-  /// parameter and returns a [Widget]. It is assumed that the passed [Widget]
-  /// will end up being a child of the [Widget] that was returned.
+  /// This is a way to add [Widget]s that are located in the widget tree
+  /// higher than the [Scaffold] widget (i.e. the main, application
+  /// framework.) [providers] is a list of functions. Each function takes a
+  /// [Widget] as a parameter and returns a [Widget]. It is assumed that the
+  /// passed [Widget] will end up being a child of the [Widget] that was
+  /// returned.
   ///
-  /// The main purpose of this parameter is to register widgets that provide an
-  /// API to our various GraphQL services.
+  /// The main purpose of this parameter is to register widgets that provide
+  /// an API to our various GraphQL services.
   ///
   /// Provider widgets should *not* require being redrawn. If they do, it'll
   /// make the entire application redraw, which is expensive and slow.
@@ -337,8 +339,8 @@ final class _RouterApp extends StatelessWidget {
 
   const _RouterApp({required this.title, required this.router});
 
-  // Return the MaterialApp widget which will define the look-and-feel for the
-  // application.
+  // Return the MaterialApp widget which will define the look-and-feel for
+  // the application.
   @override
   Widget build(BuildContext context) => MaterialApp.router(
     title: title,

--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -291,6 +291,7 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
   final PreferredSizeWidget? appBar;
 
   final Set<String> _neededRoles;
+  final ThemeMode themeMode;
 
   StandardApp({
     required this.title,
@@ -301,6 +302,7 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
     this.floatingActionButton,
     this.providers = const [],
     List<String>? neededRoles,
+    this.themeMode = ThemeMode.system,
     super.key,
   }) : _model = model,
        _neededRoles = neededRoles?.toSet() ?? {};
@@ -330,6 +332,7 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
       title: title,
       theme: _GlobalAppTheme.lightTheme,
       darkTheme: _GlobalAppTheme.darkTheme,
+      themeMode: themeMode,
       home: AuthService(
         child:
             null is T

--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -240,6 +240,15 @@ class _GlobalStateProvider<T extends ChangeNotifier> extends InheritedWidget {
 /// * Opt-in for any of our GraphQL services
 /// * Global state support (for sharing data between the drawer and main
 ///   body, for instance.)
+///
+/// If you want to share mutable state throughout your application, specify a
+/// type in the `StandardApp` generic type. The type must extend
+/// [ChangeNotifier] so that changes to the global state can be recognized by
+/// the widgets using the state. Anytime the global state is changed, it must
+/// call [notifyListeners]. A way to ensure this is to define set properties
+/// on the type. To gain access to the global state, a widget can call
+/// [StandardApp.getGlobalState] in its [build] method.
+///
 
 final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
   final T? _model;
@@ -255,23 +264,24 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
   ///
   /// [StandardApp] creates a drawer on the left side. It automatically
   /// creates a header and footer for the drawer. The main portion, however,
-  /// can be specied by the developer using this parameter.
+  /// can be specified by the developer using this parameter.
   final Widget? drawerContent;
 
   /// Creates [Widget]s that reside above the [Scaffold] widget.
   ///
-  /// This is a way to add [Widget]s that are located in the widget tree
-  /// higher than the [Scaffold] widget (i.e. the main, application
-  /// framework.) [providers] is a list of functions. Each function takes a
-  /// [Widget] as a parameter and returns a [Widget]. It is assumed that the
-  /// passed [Widget] will end up being a child of the [Widget] that was
-  /// returned.
-  ///
-  /// The main purpose of this parameter is to register widgets that provide
-  /// an API to our various GraphQL services.
+  /// [providers] is a list of functions. This is a way to add [Widget]s that
+  /// are located in the widget tree higher than the [Scaffold] widget (i.e.
+  /// the main, application framework.) Each function takes a [Widget] as a
+  /// parameter and returns a [Widget]. It is assumed that the passed [Widget]
+  /// will end up being a child of the [Widget] that was returned.
   ///
   /// Provider widgets should *not* require being redrawn. If they do, it'll
   /// make the entire application redraw, which is expensive and slow.
+  ///
+  /// The main purpose of this parameter is to register widgets that provide
+  /// an API to our various GraphQL services. For instance, if an application
+  /// wants to obtain device readings, it needs the ACSys GraphQL service. To
+  /// use it, this parameter would be set to `[ACSysProvider.factory()]`.
   final List<Widget Function({required Widget child})> providers;
 
   /// Creates a floating action button.
@@ -299,7 +309,7 @@ final class StandardApp<T extends ChangeNotifier?> extends StatelessWidget {
   ///
   /// This will return `null` if there is no global model being used. The
   /// model extends [ChangeNotifier] so the returned value should be used
-  /// with a [ListenableBuilder] so it knows when to rebuild it's dependent
+  /// with a [ListenableBuilder] so it knows when to rebuild its dependent
   /// widgets.
   static T? getGlobalState<T extends ChangeNotifier>(BuildContext context) =>
       context.getInheritedWidgetOfExactType<_GlobalStateProvider<T>>()?.model;

--- a/lib/src/device_values.dart
+++ b/lib/src/device_values.dart
@@ -73,6 +73,15 @@ sealed class DeviceValue {
     DevTimeSeries(values: var v) => v.hashCode,
     DevStatusCode(status: var v) => v.hashCode,
   };
+
+  Status? toStatus() => null;
+  double? toDouble() => null;
+  String? toText() => null;
+  List<int>? toRaw() => null;
+  List<double>? toDoubleArray() => null;
+  List<String>? toTextArray() => null;
+  List<(double, double)>? toTimeSeries() => null;
+  List<(DateTime, double)>? toTimeSeriesWithDates() => null;
 }
 
 final class DevStatusCode extends DeviceValue {
@@ -82,6 +91,9 @@ final class DevStatusCode extends DeviceValue {
 
   @override
   String toString() => "[${status.facility} ${status.error}]";
+
+  @override
+  Status? toStatus() => status;
 }
 
 /// Represents a raw, byte array.
@@ -95,6 +107,9 @@ final class DevRaw extends DeviceValue {
   final Uint8List value;
 
   const DevRaw(this.value);
+
+  @override
+  List<int>? toRaw() => value;
 }
 
 /// Represents a single, floating point number.
@@ -106,6 +121,9 @@ final class DevScalar extends DeviceValue {
   final double value;
 
   const DevScalar(this.value);
+
+  @override
+  double? toDouble() => value;
 }
 
 /// Represents an array of floating point values.
@@ -117,6 +135,9 @@ final class DevScalarArray extends DeviceValue {
   final List<double> value;
 
   const DevScalarArray(this.value);
+
+  @override
+  List<double>? toDoubleArray() => value;
 }
 
 /// Represents a single string of characters.
@@ -125,6 +146,9 @@ final class DevText extends DeviceValue {
   final String value;
 
   const DevText(this.value);
+
+  @override
+  String? toText() => value;
 }
 
 /// Represents an array of strings.
@@ -133,6 +157,9 @@ final class DevTextArray extends DeviceValue {
   final List<String> value;
 
   const DevTextArray(this.value);
+
+  @override
+  List<String>? toTextArray() => value;
 }
 
 /// Represents time-series data (i.e. a list of timestamp/value pairs.)
@@ -141,6 +168,16 @@ final class DevTimeSeries extends DeviceValue {
   final List<(double, double)> values;
 
   const DevTimeSeries(this.values);
+
+  @override
+  List<(double, double)>? toTimeSeries() => values;
+
+  @override
+  List<(DateTime, double)>? toTimeSeriesWithDates() => [
+    ...values.map(
+      (e) => (DateTime.fromMillisecondsSinceEpoch((e.$1 * 1000).toInt()), e.$2),
+    ),
+  ];
 }
 
 // The `ToDeviceValue` extension allows us to convert primitive types into a
@@ -178,68 +215,4 @@ extension TimeSeriesToDeviceValue on List<(DateTime, double)> {
   DeviceValue toDevVal() => DevTimeSeries([
     ...map((e) => (e.$1.millisecondsSinceEpoch / 1000.0, e.$2)),
   ]);
-}
-
-// The `FromDeviceValue` extension allows us to convert a `DeviceValue` into a
-// primitive type.
-
-extension FromDevValToDouble on DeviceValue {
-  double? toDouble() => switch (this) {
-    DevScalar(value: var value) => value,
-    _ => null,
-  };
-}
-
-extension FromDevValToStatus on DeviceValue {
-  Status? toStatus() => switch (this) {
-    DevStatusCode(status: var value) => value,
-    _ => null,
-  };
-}
-
-extension FromDevValToText on DeviceValue {
-  String? toText() => switch (this) {
-    DevText(value: var value) => value,
-    _ => null,
-  };
-}
-
-extension FromDevValToRaw on DeviceValue {
-  Uint8List? toRaw() => switch (this) {
-    DevRaw(value: var value) => value,
-    _ => null,
-  };
-}
-
-extension FromDevValToDoubleArray on DeviceValue {
-  List<double>? toDoubleArray() => switch (this) {
-    DevScalarArray(value: var value) => value,
-    _ => null,
-  };
-}
-
-extension FromDevValToTextArray on DeviceValue {
-  List<String>? toTextArray() => switch (this) {
-    DevTextArray(value: var value) => value,
-    _ => null,
-  };
-}
-
-extension FromDevValToTimeSeries on DeviceValue {
-  List<(double, double)>? toTimeSeries() => switch (this) {
-    DevTimeSeries(values: var values) => values,
-    _ => null,
-  };
-
-  List<(DateTime, double)>? toTimeSeriesWithDates() => switch (this) {
-    DevTimeSeries(values: var values) => [
-      ...values.map(
-        (e) => (
-          DateTime.fromMillisecondsSinceEpoch((e.$1 * 1000).toInt()),
-          e.$2,
-        ),
-      ),
-    ],
-    _ => null,
-  };
 }

--- a/lib/src/device_values.dart
+++ b/lib/src/device_values.dart
@@ -187,6 +187,10 @@ extension ToDeviceValue on DeviceValue {
   DeviceValue toDevVal() => this;
 }
 
+extension StatusToDeviceValue on Status {
+  DeviceValue toDevVal() => DevStatusCode(this);
+}
+
 extension DoubleToDeviceValue on double {
   DeviceValue toDevVal() => DevScalar(this);
 }

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1446,23 +1446,20 @@ final class ACSysService implements ACSysServiceAPI {
   @override
   Future<PlotConfigurationSnapshot> savePlotConfiguration({
     required PlotConfigurationSnapshot snapshot,
-  }) {
-    final req = GUpdatePlotConfigReq(
-      (b) =>
-          b
-            ..vars.cfg = jsonEncode(snapshot.toJson())
-            ..vars.id = snapshot.configurationId?._value
-            ..vars.name = snapshot.configurationName,
+  }) async {
+    final id = await _queryAcsys(
+      GUpdatePlotConfigReq(
+        (b) =>
+            b
+              ..vars.cfg = jsonEncode(snapshot.toJson())
+              ..vars.id = snapshot.configurationId?._value
+              ..vars.name = snapshot.configurationName,
+      ),
+      xlat: (GUpdatePlotConfigData data) => data.updatePlotConfiguration,
     );
 
-    return _queryAcsys(
-      req,
-      xlat: (GUpdatePlotConfigData data) => data.updatePlotConfiguration,
-    ).then(
-      (id) =>
-          snapshot
-            ..configurationId = id == null ? null : PlotConfigId._fromInt(id),
-    );
+    snapshot.configurationId = id == null ? null : PlotConfigId._fromInt(id);
+    return snapshot;
   }
 }
 

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -879,79 +879,48 @@ final class ACSysService implements ACSysServiceAPI {
   // The caller sends in a GraphQL request and, optionally, a function to
   // translate the GraphQL response data into some other data type.
 
+  Future<Result> _executeRequest<TData, TVars, Result>(
+    Client client,
+    OperationRequest<TData, TVars> req, {
+    Result Function(TData)? xlat,
+  }) async {
+    final response = await client
+        .request(req)
+        .firstWhere((response) => !response.loading);
+
+    if (response.hasErrors) {
+      if (response.linkException != null) {
+        throw response.linkException!;
+      } else if (response.graphqlErrors != null) {
+        throw ACSysGraphQLException(response.graphqlErrors.toString());
+      } else {
+        throw ACSysGraphQLException("unknown error");
+      }
+    } else {
+      final data = response.data;
+
+      if (data != null) {
+        return xlat != null ? xlat(data) : data as Result;
+      } else {
+        throw ACSysGraphQLException("no data was returned from request");
+      }
+    }
+  }
+
   Future<Result> _queryAcsys<TData, TVars, Result>(
     OperationRequest<TData, TVars> req, {
     Result Function(TData)? xlat,
-  }) =>
-      _q.request(req).firstWhere((response) => !response.loading).then((value) {
-        if (value.hasErrors) {
-          if (value.linkException != null) {
-            throw value.linkException!;
-          } else if (value.graphqlErrors != null) {
-            throw ACSysGraphQLException(value.graphqlErrors.toString());
-          } else {
-            throw ACSysGraphQLException("unknown error");
-          }
-        } else {
-          final data = value.data;
-
-          if (data != null) {
-            return xlat != null ? xlat(data) : data as Result;
-          } else {
-            throw ACSysGraphQLException("no data was returned from request");
-          }
-        }
-      });
+  }) => _executeRequest(_q, req, xlat: xlat);
 
   Future<Result> _queryDevDb<TData, TVars, Result>(
     OperationRequest<TData, TVars> req, {
     Result Function(TData)? xlat,
-  }) => _qDevDb.request(req).firstWhere((response) => !response.loading).then((
-    value,
-  ) {
-    if (value.hasErrors) {
-      if (value.linkException != null) {
-        throw value.linkException!;
-      } else if (value.graphqlErrors != null) {
-        throw ACSysGraphQLException(value.graphqlErrors.toString());
-      } else {
-        throw ACSysGraphQLException("unknown error");
-      }
-    } else {
-      final data = value.data;
-
-      if (data != null) {
-        return xlat != null ? xlat(data) : data as Result;
-      } else {
-        throw ACSysGraphQLException("no data was returned from request");
-      }
-    }
-  });
+  }) => _executeRequest(_qDevDb, req, xlat: xlat);
 
   Future<Result> _queryAlarms<TData, TVars, Result>(
     OperationRequest<TData, TVars> req, {
     Result Function(TData)? xlat,
-  }) => _qAlarms.request(req).firstWhere((response) => !response.loading).then((
-    value,
-  ) {
-    if (value.hasErrors) {
-      if (value.linkException != null) {
-        throw value.linkException!;
-      } else if (value.graphqlErrors != null) {
-        throw ACSysGraphQLException(value.graphqlErrors.toString());
-      } else {
-        throw ACSysGraphQLException("unknown error");
-      }
-    } else {
-      final data = value.data;
-
-      if (data != null) {
-        return xlat != null ? xlat(data) : data as Result;
-      } else {
-        throw ACSysGraphQLException("no data was returned from request");
-      }
-    }
-  });
+  }) => _executeRequest(_qAlarms, req, xlat: xlat);
 
   /// Returns information about devices. The caller provides a list of device
   /// names and will receive a list of `DeviceInfo` objects. The order of the

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1316,26 +1316,19 @@ final class ACSysService implements ACSysServiceAPI {
   Future<SettingStatus> submit({
     required String forDRF,
     required DeviceValue newSetting,
-  }) {
-    // Define a nested function which converts the GraphQL reply into a
-    // SettingStatus.
-
-    xlat(e) => SettingStatus(
-      facilityCode: e.setDevice.status & 255,
-      errorCode: e.setDevice.status ~/ 256,
-    );
-
-    // Build the request.
-
-    final req = GSetDeviceReq(
+  }) => _queryAcsys(
+    GSetDeviceReq(
       (b) =>
           b
             ..vars.device = forDRF
             ..vars.value = newSetting._toGDevValue(),
-    );
-
-    return _queryAcsys(req, xlat: xlat);
-  }
+    ),
+    xlat:
+        (e) => SettingStatus(
+          facilityCode: e.setDevice.status & 255,
+          errorCode: e.setDevice.status ~/ 256,
+        ),
+  );
 
   @override
   Future<SettingStatus> sendCommand({
@@ -1386,97 +1379,69 @@ final class ACSysService implements ACSysServiceAPI {
   }
 
   @override
-  Future<List<PlotConfigurationListing>> listPlotConfigurations() {
-    final req = GPlotConfigsReq(
-      (b) => b..fetchPolicy = FetchPolicy.NetworkOnly,
-    );
-
-    return _queryAcsys(
-      req,
-      xlat:
-          (GPlotConfigsData data) =>
-              data.plotConfiguration
-                  .map(
-                    (e) => PlotConfigurationListing(
-                      configurationId: PlotConfigId._fromInt(e.configId),
-                      configurationName: e.configName,
-                    ),
-                  )
-                  .toList(),
-    );
-  }
+  Future<List<PlotConfigurationListing>> listPlotConfigurations() =>
+      _queryAcsys(
+        GPlotConfigsReq((b) => b..fetchPolicy = FetchPolicy.NetworkOnly),
+        xlat:
+            (GPlotConfigsData data) =>
+                data.plotConfiguration
+                    .map(
+                      (e) => PlotConfigurationListing(
+                        configurationId: PlotConfigId._fromInt(e.configId),
+                        configurationName: e.configName,
+                      ),
+                    )
+                    .toList(),
+      );
 
   @override
   Future<void> removePlotConfiguration({
     required PlotConfigId configurationId,
-  }) {
-    final req = GDeletePlotConfigReq(
-      (b) => b..vars.id = configurationId._value,
-    );
-
-    return _queryAcsys(req, xlat: (GDeletePlotConfigData data) => ());
-  }
+  }) => _queryAcsys(
+    GDeletePlotConfigReq((b) => b..vars.id = configurationId._value),
+    xlat: (GDeletePlotConfigData data) => (),
+  );
 
   @override
-  Future<PlotConfigurationSnapshot?> retrieveLastUserConfiguration() {
-    final req = GUsersLastConfigReq();
+  Future<PlotConfigurationSnapshot?> retrieveLastUserConfiguration() =>
+      _queryAcsys(
+        GUsersLastConfigReq(),
+        xlat: (GUsersLastConfigData data) {
+          final e = data.usersLastConfiguration;
 
-    return _queryAcsys(
-      req,
-      xlat: (GUsersLastConfigData data) {
-        final e = data.usersLastConfiguration;
-
-        return e == null
-            ? null
-            : PlotConfigurationSnapshot.fromJson(
-              PlotConfigId._fromInt(0),
-              "n/a",
-              jsonDecode(e),
-            );
-      },
-    );
-  }
+          return e == null
+              ? null
+              : PlotConfigurationSnapshot.fromJson(
+                PlotConfigId._fromInt(0),
+                "n/a",
+                jsonDecode(e),
+              );
+        },
+      );
 
   @override
   Future<void> saveUserConfiguration({
     required PlotConfigurationSnapshot snapshot,
-  }) {
-    final req = GSetUsersConfigReq(
-      (b) => b..vars.cfg = jsonEncode(snapshot.toJson()),
-    );
-
-    return _queryAcsys(req, xlat: (GSetUsersConfigData data) => ());
-  }
+  }) => _queryAcsys(
+    GSetUsersConfigReq((b) => b..vars.cfg = jsonEncode(snapshot.toJson())),
+    xlat: (GSetUsersConfigData data) => (),
+  );
 
   @override
   Future<PlotConfigurationSnapshot?> retrievePlotConfiguration({
     required PlotConfigId configurationId,
-  }) {
-    final req = GPlotConfigsReq((b) => b..vars.id = configurationId._value);
-
-    return _queryAcsys(
-      req,
-      xlat:
-          (GPlotConfigsData data) => data.plotConfiguration.map(
-            (e) => PlotConfigurationSnapshot.fromJson(
-              PlotConfigId._fromInt(e.configId),
-              e.configName,
-              jsonDecode(e.config),
+  }) async =>
+      (await _queryAcsys(
+        GPlotConfigsReq((b) => b..vars.id = configurationId._value),
+        xlat:
+            (GPlotConfigsData data) => data.plotConfiguration.map(
+              (e) => PlotConfigurationSnapshot.fromJson(
+                PlotConfigId._fromInt(e.configId),
+                e.configName,
+                jsonDecode(e.config),
+              ),
             ),
-          ),
-    ).then((value) {
-      switch (value.toList()) {
-        case []:
-          return null;
-        case [PlotConfigurationSnapshot e]:
-          return e;
-        default:
-          throw const ACSysConfigurationException(
-            "multiple configurations found",
-          );
-      }
-    });
-  }
+      )).firstOrNull;
 
   @override
   Future<PlotConfigurationSnapshot> savePlotConfiguration({

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1334,7 +1334,7 @@ final class ACSysService implements ACSysServiceAPI {
   Future<SettingStatus> sendCommand({
     required String toDRF,
     required String value,
-  }) => submit(forDRF: toDRF, newSetting: DevText(value));
+  }) => submit(forDRF: toDRF, newSetting: value.toDevVal());
 
   @override
   Stream<AnalogAlarmStatus> monitorAnalogAlarmProperty(List<String> drfs) =>
@@ -1468,11 +1468,10 @@ final class ACSysService implements ACSysServiceAPI {
 
 extension on GStartPlotData_startPlot_data_channelData_result {
   DeviceValue toDevValue() => switch (this) {
-    GStartPlotData_startPlot_data_channelData_result__asScalar val => DevScalar(
-      val.scalarValue,
-    ),
+    GStartPlotData_startPlot_data_channelData_result__asScalar val =>
+      val.scalarValue.toDevVal(),
     GStartPlotData_startPlot_data_channelData_result__asScalarArray val =>
-      DevScalarArray(val.scalarArrayValue.toList()),
+      val.scalarArrayValue.toList().toDevVal(),
     _ => throw ACSysTypeException("unexpected data type, $runtimeType"),
   };
 }
@@ -1480,17 +1479,15 @@ extension on GStartPlotData_startPlot_data_channelData_result {
 extension on GStreamDataData_acceleratorData_data_result {
   DeviceValue toDevValue() => switch (this) {
     GStreamDataData_acceleratorData_data_result__asStatusReply val =>
-      DevStatusCode(Status.fromInt(val.status)),
-    GStreamDataData_acceleratorData_data_result__asScalar val => DevScalar(
-      val.scalarValue,
-    ),
+      Status.fromInt(val.status).toDevVal(),
+    GStreamDataData_acceleratorData_data_result__asScalar val =>
+      val.scalarValue.toDevVal(),
     GStreamDataData_acceleratorData_data_result__asScalarArray val =>
-      DevScalarArray(val.scalarArrayValue.toList()),
-    GStreamDataData_acceleratorData_data_result__asText val => DevText(
-      val.textValue,
-    ),
+      val.scalarArrayValue.toList().toDevVal(),
+    GStreamDataData_acceleratorData_data_result__asText val =>
+      val.textValue.toDevVal(),
     GStreamDataData_acceleratorData_data_result__asTextArray val =>
-      DevTextArray(val.textArrayValue.toList()),
+      val.textArrayValue.toList().toDevVal(),
     _ => throw ACSysTypeException("unexpected data type, $runtimeType"),
   };
 }
@@ -1498,17 +1495,15 @@ extension on GStreamDataData_acceleratorData_data_result {
 extension on GReadDevicesData_acceleratorData_data_result {
   DeviceValue toDevValue() => switch (this) {
     GReadDevicesData_acceleratorData_data_result__asStatusReply val =>
-      DevStatusCode(Status.fromInt(val.status)),
-    GReadDevicesData_acceleratorData_data_result__asScalar val => DevScalar(
-      val.scalarValue,
-    ),
+      Status.fromInt(val.status).toDevVal(),
+    GReadDevicesData_acceleratorData_data_result__asScalar val =>
+      val.scalarValue.toDevVal(),
     GReadDevicesData_acceleratorData_data_result__asScalarArray val =>
-      DevScalarArray(val.scalarArrayValue.toList()),
-    GReadDevicesData_acceleratorData_data_result__asText val => DevText(
-      val.textValue,
-    ),
+      val.scalarArrayValue.toList().toDevVal(),
+    GReadDevicesData_acceleratorData_data_result__asText val =>
+      val.textValue.toDevVal(),
     GReadDevicesData_acceleratorData_data_result__asTextArray val =>
-      DevTextArray(val.textArrayValue.toList()),
+      val.textArrayValue.toList().toDevVal(),
     _ => throw ACSysTypeException("unexpected data type, $runtimeType"),
   };
 }

--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -1614,9 +1614,10 @@ extension on GStartPlotData_startPlot {
 
 extension on DeviceValue {
   GDevValueBuilder _toGDevValue() => switch (this) {
-    DevStatusCode() => throw ACSysInvArgException(
-      "DevStatusCode is a read-only status reply and is not writable",
-    ),
+    DevStatusCode() =>
+      throw ACSysInvArgException(
+        "DevStatusCode is a read-only status reply and is not writable",
+      ),
     DevRaw(value: var v) => GDevValueBuilder()..rawVal = ListBuilder(v),
     DevScalar(value: var v) => GDevValueBuilder()..scalarVal = v,
     DevScalarArray(value: var v) =>


### PR DESCRIPTION
This PR adds a few refactored changes and new features.

- Use defined methods instead of duplicating the code.
- Remove an extension section since it could be expressed simpler as a virtual method.
- Add a `themeMode` parameter to `StandardApp()` -- it defaults to `ThemeMode.system`.