### PR TITLE
Dev db cache

### DIFF
--- a/lib/src/service/acsys_service.dart
+++ b/lib/src/service/acsys_service.dart
@@ -873,7 +873,11 @@ final class ACSysService implements ACSysServiceAPI {
                "https://acsys-proxy.fnal.gov:${port ?? 8000}/devdb",
                defaultHeaders: _buildAuthHeader(jwt),
              ),
-             cache: Cache(),
+             cache: Cache(
+               possibleTypes: {
+                 'DeviceProperty': {'ReadingProp', 'SettingProp'},
+               },
+             ),
            ),
        _qAlarms =
            alarmsQueryClient ??

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.5.0
+version: 0.5.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
This changes the DevDB client to add `possibleTypes` to the Cache property. This is needed when the schema uses implementations. [Ferry](https://ferrygraphql.com/docs/cache-configuration#passing-the-possibletypes-map) will run into errors normalizing/denormalizing cached data