### PR TITLE
Minor fixes to the Panel widgets

### DIFF
--- a/lib/src/widgets/param_panel.dart
+++ b/lib/src/widgets/param_panel.dart
@@ -68,10 +68,8 @@ class ParameterPanel extends StatelessWidget {
                 padding: const .only(bottom: 8.0),
                 child: Text(
                   title,
-                  style: TextStyle(
+                  style: theme.textTheme.titleMedium!.copyWith(
                     color: theme.colorScheme.primary,
-                    fontSize: 16,
-                    fontWeight: .bold,
                   ),
                 ),
               ),

--- a/lib/src/widgets/param_row.dart
+++ b/lib/src/widgets/param_row.dart
@@ -103,7 +103,7 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
   @override
   Widget build(final BuildContext context) {
     final theme = Theme.of(context);
-    final style = theme.textTheme.titleMedium!;
+    final style = theme.textTheme.bodyMedium!;
 
     return Row(
       mainAxisAlignment: .spaceBetween,

--- a/lib/src/widgets/param_row.dart
+++ b/lib/src/widgets/param_row.dart
@@ -114,61 +114,17 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
           child: Text(widget.label, style: style, overflow: .clip),
         ),
         Expanded(
-          flex: 1,
           child: Row(
             mainAxisAlignment: .end,
             children: [
               if (isEditable)
                 Flexible(
                   child: _isEditing
-                      ? TextField(
-                          controller: _controller,
-                          focusNode: _focusNode,
-                          style: style,
-                          textAlign: .right,
-                          decoration: const InputDecoration(
-                            isDense: true,
-                            contentPadding: .symmetric(
-                              horizontal: 8.0,
-                              vertical: 4.0,
-                            ),
-                            border: OutlineInputBorder(),
-                          ),
-                          onSubmitted: (_) => _submitValue(),
-                        )
-                      : GestureDetector(
-                          onTap: _enterEditMode,
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest,
-                              borderRadius: .circular(4.0),
-                            ),
-                            child: widget.valueBuilder != null
-                                ? _ValueBuilder(
-                                    builder: widget.valueBuilder!,
-                                    style: style,
-                                  )
-                                : Text(
-                                    widget.value!,
-                                    style: style,
-                                    overflow: .clip,
-                                    textAlign: .right,
-                                  ),
-                          ),
-                        ),
-                )
-              else if (widget.valueBuilder != null)
-                _ValueBuilder(
-                  builder: widget.valueBuilder!,
-                  style: style.copyWith(color: widget.valueColor),
+                      ? _buildTextField(style)
+                      : _buildEditableValue(theme, style),
                 )
               else
-                Text(
-                  widget.value!,
-                  style: style.copyWith(color: widget.valueColor),
-                  overflow: .clip,
-                  textAlign: .right,
-                ),
+                _buildValueWidget(style),
               if (widget.units != null) ...[
                 const SizedBox(width: 4),
                 Text(widget.units!, style: style, overflow: .clip),
@@ -178,6 +134,44 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
         ),
       ],
     );
+  }
+
+  Widget _buildTextField(TextStyle style) => TextField(
+    controller: _controller,
+    focusNode: _focusNode,
+    style: style,
+    textAlign: .right,
+    decoration: const InputDecoration(
+      isDense: true,
+      contentPadding: .symmetric(horizontal: 8.0, vertical: 4.0),
+      border: OutlineInputBorder(),
+    ),
+    onSubmitted: (_) => _submitValue(),
+  );
+
+  Widget _buildEditableValue(ThemeData theme, TextStyle style) =>
+      GestureDetector(
+        onTap: _enterEditMode,
+        child: Container(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+            borderRadius: .circular(4.0),
+          ),
+          child: _buildValueWidget(style),
+        ),
+      );
+
+  Widget _buildValueWidget(TextStyle style) {
+    final valueStyle = style.copyWith(color: widget.valueColor);
+
+    return widget.valueBuilder != null
+        ? _ValueBuilder(builder: widget.valueBuilder!, style: valueStyle)
+        : Text(
+            widget.value!,
+            style: valueStyle,
+            overflow: .clip,
+            textAlign: .right,
+          );
   }
 }
 

--- a/lib/src/widgets/param_row.dart
+++ b/lib/src/widgets/param_row.dart
@@ -104,7 +104,6 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
   Widget build(final BuildContext context) {
     final theme = Theme.of(context);
     final style = theme.textTheme.titleMedium!;
-    final isEditable = widget.onValueChanged != null;
 
     return Row(
       mainAxisAlignment: .spaceBetween,
@@ -117,7 +116,7 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
           child: Row(
             mainAxisAlignment: .end,
             children: [
-              if (isEditable)
+              if (widget.onValueChanged != null)
                 Flexible(
                   child: _isEditing
                       ? _buildTextField(style)

--- a/lib/src/widgets/param_row.dart
+++ b/lib/src/widgets/param_row.dart
@@ -103,7 +103,7 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
   @override
   Widget build(final BuildContext context) {
     final theme = Theme.of(context);
-    final style = theme.textTheme.titleMedium;
+    final style = theme.textTheme.titleMedium!;
     final isEditable = widget.onValueChanged != null;
 
     return Row(
@@ -140,9 +140,7 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
                           onTap: _enterEditMode,
                           child: Container(
                             decoration: BoxDecoration(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.surfaceContainerHighest,
+                              color: theme.colorScheme.surfaceContainerHighest,
                               borderRadius: .circular(4.0),
                             ),
                             child: widget.valueBuilder != null
@@ -160,11 +158,14 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
                         ),
                 )
               else if (widget.valueBuilder != null)
-                _ValueBuilder(builder: widget.valueBuilder!, style: style)
+                _ValueBuilder(
+                  builder: widget.valueBuilder!,
+                  style: style.copyWith(color: widget.valueColor),
+                )
               else
                 Text(
                   widget.value!,
-                  style: style,
+                  style: style.copyWith(color: widget.valueColor),
                   overflow: .clip,
                   textAlign: .right,
                 ),

--- a/lib/src/widgets/param_row.dart
+++ b/lib/src/widgets/param_row.dart
@@ -125,10 +125,8 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
                 )
               else
                 _buildValueWidget(style),
-              if (widget.units != null) ...[
-                const SizedBox(width: 4),
+              if (widget.units != null)
                 Text(widget.units!, style: style, overflow: .clip),
-              ],
             ],
           ),
         ),
@@ -164,14 +162,17 @@ class _ParameterPanelRowState extends State<ParameterPanelRow> {
   Widget _buildValueWidget(TextStyle style) {
     final valueStyle = style.copyWith(color: widget.valueColor);
 
-    return widget.valueBuilder != null
-        ? _ValueBuilder(builder: widget.valueBuilder!, style: valueStyle)
-        : Text(
-            widget.value!,
-            style: valueStyle,
-            overflow: .clip,
-            textAlign: .right,
-          );
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4.0),
+      child: widget.valueBuilder != null
+          ? _ValueBuilder(builder: widget.valueBuilder!, style: valueStyle)
+          : Text(
+              widget.value!,
+              style: valueStyle,
+              overflow: .clip,
+              textAlign: .right,
+            ),
+    );
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 0.6.0
+version: 0.6.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
Less than a day old, and I already have tweaks for the panels widgets. 🙄

- I found a few, hardcoded text styles. They have been replaced and are now using our theme's settings.
- The row text is now slightly smaller than the title text. This is more pleasing to me (hopefully others agree.) It also lets the panels fit in a smaller space.
- Did a little code refactoring to remove duplicated code.
- Fix a bug where the `valueColor` wasn't actually changing the color.
- Added some padding around the value so the highlight box around settable values has some space.