### PR TITLE
Add App Info to Drawer

### DIFF
--- a/lib/src/app_scaffold.dart
+++ b/lib/src/app_scaffold.dart
@@ -190,11 +190,21 @@ final class _DrawerHeader extends StatelessWidget {
 }
 
 final class _Drawer extends StatelessWidget {
+  static const _appName = String.fromEnvironment('APP_NAME');
+  static const _appVersion = String.fromEnvironment('APP_VERSION');
+
+  static String get _appInfo {
+    if (_appName.isEmpty && _appVersion.isEmpty) return 'Unknown App Info';
+    final name = _appName.isEmpty ? '' : _appName;
+    final version = _appVersion.isEmpty ? '' : 'v$_appVersion';
+    final sep = name.isNotEmpty && version.isNotEmpty ? ' ' : '';
+    return '$name$sep$version';
+  }
+
   final Widget? content;
   final Set<String> neededRoles;
 
   const _Drawer(this.content, this.neededRoles);
-
   @override
   Widget build(BuildContext context) {
     final ThemeData td = Theme.of(context);
@@ -215,8 +225,18 @@ final class _Drawer extends StatelessWidget {
               ),
             ),
             Divider(),
+            Padding(
+              padding: const .only(bottom: 8.0),
+              child: Text(
+                _appInfo,
+                textAlign: .center,
+                style: td.textTheme.bodySmall?.copyWith(
+                  color: td.disabledColor,
+                ),
+              ),
+            ),
             Text(
-              "© 2025, 2026 Fermi Forward Discovery\nGroup, LLC, All rights reserved.",
+              '© 2025, 2026 Fermi Forward Discovery\nGroup, LLC, All rights reserved.',
               textAlign: .center,
               style: td.textTheme.bodySmall?.copyWith(color: td.disabledColor),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 1.1.1
+version: 1.1.2
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,42 +4,42 @@ version: 1.1.1
 publish_to: none
 
 environment:
-    sdk: ">=3.12.0 <4.0.0"
-    flutter: ">=3.27.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
-    flutter:
-        sdk: flutter
+  flutter:
+    sdk: flutter
 
-    # One of our app types uses the GoRouter widget, so we need to include this
-    # package.
+  # One of our app types uses the GoRouter widget, so we need to include this
+  # package.
 
-    go_router: ^12.1.0
+  go_router: ^12.1.0
 
-    opentelemetry: ^0.18.10
-    toastification: ^3.2.0
+  opentelemetry: ^0.18.10
+  toastification: ^3.2.0
 
-    # Needed for KeyCloak authentication support.
+  # Needed for KeyCloak authentication support.
 
-    flutter_controls_auth:
-      git:
-        url: https://github.com/fermi-ad/flutter-controls-auth.git
-        ref: main
+  flutter_controls_auth:
+    git:
+      url: https://github.com/fermi-ad/flutter-controls-auth.git
+      ref: main
     
-    bison_design_system:
-      git:
-        url: https://github.com/fermi-ad/flutter-bison-design-system.git
-        ref: main
+  bison_design_system:
+    git:
+      url: https://github.com/fermi-ad/flutter-bison-design-system.git
+      ref: main
 
 dev_dependencies:
-    flutter_test:
-        sdk: flutter
-    flutter_lints: ^6.0.0
-    analyzer: ^8.4.0
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+  analyzer: ^8.4.0
 
-    test: ^1.24.3
-    mocktail: ^1.0.4
-    gql_exec: ^1.1.1-alpha+1699813812660
+  test: ^1.24.3
+  mocktail: ^1.0.4
+  gql_exec: ^1.1.1-alpha+1699813812660
 
 flutter:
     fonts:


### PR DESCRIPTION
The app looks for two environment variables, `APP_NAME` and `APP_VERSION`, and displays them in the `Drawer` footer (above the copyright message.) We need to update our Flutter workflow file to extract these two pieces of info from the app's `pubspec.yaml` file at build time.

This screenshot is what's displayed when the variables aren't set.

<img width="329" height="657" alt="Screenshot 2026-07-16 at 4 05 10 PM" src="https://github.com/user-attachments/assets/2a09538c-8108-4d5a-bb43-db0f16f994d3" />