### PR TITLE
Add tests and workflow

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "main"
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   test:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,6 +12,9 @@ jobs:
   test:
     uses: fermi-ad/.github/.github/workflows/flutter-integration.yaml@add7aae28c8a3f714dbd11341776cede88a3f33e
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,20 @@
+name: Continuous Integration for Flutter applications
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  test:
+    uses: fermi-ad/.github/.github/workflows/flutter-integration.yaml@add7aae28c8a3f714dbd11341776cede88a3f33e
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test: 
+          - smoke_test
+    # Change to true to pull in git submodules during build
+    with:
+      pull-git-submodules: false
+      coverage-exclude: "|tool/setup_git_hooks.dart"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -17,9 +17,6 @@ jobs:
       pull-requests: write
     strategy:
       fail-fast: false
-      matrix:
-        test: 
-          - smoke_test
     # Change to true to pull in git submodules during build
     with:
       pull-git-submodules: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.2
+
+* Adds our standard GitHub Flutter integration workflow.
+* Adds some basic unit and widget tests (not enough for high coverage).
+* Bumps the min Flutter version to match the min Dart version.
+* Small formatting changes.
+* Moves a doc comment to top of its file.
+* Pins git dependencies rather than pointing only to "main".
+
 ## 0.0.1
 
 * TODO: Describe initial release.

--- a/lib/src/otel_tracing.dart
+++ b/lib/src/otel_tracing.dart
@@ -6,6 +6,66 @@ import 'package:opentelemetry/api.dart'
 
 export 'package:opentelemetry/api.dart' show Span;
 
+/// ---
+/// # OpenTelemetry Usage Guidance
+///
+/// ## Overview
+///
+/// OpenTelemetry tracing is enabled by default (opt-out) for all apps using this package's entrypoints.
+///
+/// - Auto-instrumentation is initialized automatically in `runFermiApp` and `runFermiRouterApp`.
+/// - All spans are exported to the console by default (see `ConsoleExporter`).
+/// - You can override the exporter by calling `initOpenTelemetry(exporter: ...)` before app startup.
+///
+/// ## Manual Instrumentation
+///
+/// Use the helpers below for manual spans and events:
+///
+/// ```dart
+/// final span = startSpan('operation', attributes: {'key': 'value'});
+/// try {
+///   // ... your code ...
+///   addEvent(span, 'eventName', attributes: {'foo': 42});
+/// } finally {
+///   endSpan(span);
+/// }
+/// ```
+///
+/// Or use the convenience wrappers for automatic span management:
+///
+/// ```dart
+/// runWithSpan('operation', (span) {
+///   // ... your code ...
+/// });
+///
+/// await runWithSpanAsync('asyncOp', (span) async {
+///   // ... your async code ...
+/// });
+/// ```
+///
+/// ## Dependency Injection and Testing
+///
+/// Use the `AppTracer` interface and the `appTracer` instance for testable code:
+///
+/// ```dart
+/// class MyService {
+///   final AppTracer tracer;
+///   MyService(this.tracer);
+///   void doWork() {
+///     tracer.runWithSpan('work', (span) {
+///       // ...
+///     });
+///   }
+/// }
+/// ```
+///
+/// In tests, inject a mock tracer if needed.
+///
+/// ## Opting Out
+///
+/// To disable tracing, you can override `initOpenTelemetry` with a no-op exporter or skip calling it (not recommended for most apps).
+/// ---
+
 /// OpenTelemetry singleton tracer for manual instrumentation
 late final otel.Tracer otelTracer;
 bool _otelInitialized = false;
@@ -164,63 +224,3 @@ class _GlobalAppTracer implements AppTracer {
 
 /// The default tracer instance for use in most apps (opt-out global).
 AppTracer appTracer = _GlobalAppTracer();
-
-/// ---
-/// # OpenTelemetry Usage Guidance
-///
-/// ## Overview
-///
-/// OpenTelemetry tracing is enabled by default (opt-out) for all apps using this package's entrypoints.
-///
-/// - Auto-instrumentation is initialized automatically in `runFermiApp` and `runFermiRouterApp`.
-/// - All spans are exported to the console by default (see `ConsoleExporter`).
-/// - You can override the exporter by calling `initOpenTelemetry(exporter: ...)` before app startup.
-///
-/// ## Manual Instrumentation
-///
-/// Use the helpers below for manual spans and events:
-///
-/// ```dart
-/// final span = startSpan('operation', attributes: {'key': 'value'});
-/// try {
-///   // ... your code ...
-///   addEvent(span, 'eventName', attributes: {'foo': 42});
-/// } finally {
-///   endSpan(span);
-/// }
-/// ```
-///
-/// Or use the convenience wrappers for automatic span management:
-///
-/// ```dart
-/// runWithSpan('operation', (span) {
-///   // ... your code ...
-/// });
-///
-/// await runWithSpanAsync('asyncOp', (span) async {
-///   // ... your async code ...
-/// });
-/// ```
-///
-/// ## Dependency Injection and Testing
-///
-/// Use the `AppTracer` interface and the `appTracer` instance for testable code:
-///
-/// ```dart
-/// class MyService {
-///   final AppTracer tracer;
-///   MyService(this.tracer);
-///   void doWork() {
-///     tracer.runWithSpan('work', (span) {
-///       // ...
-///     });
-///   }
-/// }
-/// ```
-///
-/// In tests, inject a mock tracer if needed.
-///
-/// ## Opting Out
-///
-/// To disable tracing, you can override `initOpenTelemetry` with a no-op exporter or skip calling it (not recommended for most apps).
-/// ---

--- a/lib/src/otel_tracing.dart
+++ b/lib/src/otel_tracing.dart
@@ -61,7 +61,7 @@ export 'package:opentelemetry/api.dart' show Span;
 ///
 /// ## Opting Out
 ///
-/// To disable tracing, you can override `initOpenTelemetry` with a no-op exporter or skip calling it (not recommended for most apps).
+/// To disable tracing, you can call `initOpenTelemetry` with a no-op exporter or skip calling it (not recommended for most apps).
 /// ---
 
 /// OpenTelemetry singleton tracer for manual instrumentation

--- a/lib/src/otel_tracing.dart
+++ b/lib/src/otel_tracing.dart
@@ -1,8 +1,6 @@
 import 'package:opentelemetry/api.dart' as otel;
 import 'package:opentelemetry/sdk.dart'
     show TracerProviderBase, SimpleSpanProcessor, ConsoleExporter, SpanExporter;
-import 'package:opentelemetry/api.dart'
-    show registerGlobalTracerProvider, globalTracerProvider, Attribute;
 
 export 'package:opentelemetry/api.dart' show Span;
 
@@ -71,16 +69,16 @@ late final otel.Tracer otelTracer;
 bool _otelInitialized = false;
 
 /// More idiomatic Dart 3+ pattern matching for attribute conversion
-Attribute _toAttribute(String key, Object? value) => switch (value) {
-  String v => Attribute.fromString(key, v),
-  bool v => Attribute.fromBoolean(key, v),
-  double v => Attribute.fromDouble(key, v),
-  int v => Attribute.fromInt(key, v),
-  List<String> v => Attribute.fromStringList(key, v),
-  List<bool> v => Attribute.fromBooleanList(key, v),
-  List<double> v => Attribute.fromDoubleList(key, v),
-  List<int> v => Attribute.fromIntList(key, v),
-  _ => Attribute.fromString(key, value.toString()),
+otel.Attribute _toAttribute(String key, Object? value) => switch (value) {
+  String v => otel.Attribute.fromString(key, v),
+  bool v => otel.Attribute.fromBoolean(key, v),
+  double v => otel.Attribute.fromDouble(key, v),
+  int v => otel.Attribute.fromInt(key, v),
+  List<String> v => otel.Attribute.fromStringList(key, v),
+  List<bool> v => otel.Attribute.fromBooleanList(key, v),
+  List<double> v => otel.Attribute.fromDoubleList(key, v),
+  List<int> v => otel.Attribute.fromIntList(key, v),
+  _ => otel.Attribute.fromString(key, value.toString()),
 };
 
 /// Initializes OpenTelemetry auto-instrumentation and tracer provider.
@@ -93,8 +91,8 @@ Future<void> initOpenTelemetry({
   final tracerProvider = TracerProviderBase(
     processors: [SimpleSpanProcessor(exporter ?? ConsoleExporter())],
   );
-  registerGlobalTracerProvider(tracerProvider);
-  otelTracer = globalTracerProvider.getTracer(serviceName);
+  otel.registerGlobalTracerProvider(tracerProvider);
+  otelTracer = otel.globalTracerProvider.getTracer(serviceName);
   _otelInitialized = true;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_controls_core
 description: A Flutter package to write Fermilab applications.
-version: 1.2.1
+version: 1.2.2
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.12.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
@@ -24,12 +24,12 @@ dependencies:
   flutter_controls_auth:
     git:
       url: https://github.com/fermi-ad/flutter-controls-auth.git
-      ref: main
+      ref: deb0eb6bbbaf74a70d637dbcfca5c298d8340119
     
   bison_design_system:
     git:
       url: https://github.com/fermi-ad/flutter-bison-design-system.git
-      ref: main
+      ref: 5ffc3a5eddd792e9c039ed732246982ca350b243
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,8 @@ dependencies:
   go_router: ^12.1.0
   opentelemetry: ^0.18.10
   toastification: ^3.2.0
-  fixnum: ^1.1.1
 
   # Needed for KeyCloak authentication support.
-
   flutter_controls_auth:
     git:
       url: https://github.com/fermi-ad/flutter-controls-auth.git
@@ -41,6 +39,7 @@ dev_dependencies:
   test: ^1.24.3
   mocktail: ^1.0.4
   gql_exec: ^1.1.1-alpha+1699813812660
+  fixnum: ^1.1.1
 
 flutter:
     fonts:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dev_dependencies:
   test: ^1.24.3
   mocktail: ^1.0.4
   gql_exec: ^1.1.1-alpha+1699813812660
-  fixnum: ^1.1.1
 
 flutter:
     fonts:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   go_router: ^12.1.0
   opentelemetry: ^0.18.10
   toastification: ^3.2.0
+  fixnum: ^1.1.1
 
   # Needed for KeyCloak authentication support.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,12 +21,12 @@ dependencies:
   flutter_controls_auth:
     git:
       url: https://github.com/fermi-ad/flutter-controls-auth.git
-      ref: deb0eb6bbbaf74a70d637dbcfca5c298d8340119
+      ref: main
 
   bison_design_system:
     git:
       url: https://github.com/fermi-ad/flutter-bison-design-system.git
-      ref: 5ffc3a5eddd792e9c039ed732246982ca350b243
+      ref: main
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
 
   # One of our app types uses the GoRouter widget, so we need to include this
   # package.
-
   go_router: ^12.1.0
   opentelemetry: ^0.18.10
   toastification: ^3.2.0
@@ -23,7 +22,7 @@ dependencies:
     git:
       url: https://github.com/fermi-ad/flutter-controls-auth.git
       ref: deb0eb6bbbaf74a70d637dbcfca5c298d8340119
-    
+
   bison_design_system:
     git:
       url: https://github.com/fermi-ad/flutter-bison-design-system.git
@@ -41,49 +40,52 @@ dev_dependencies:
   gql_exec: ^1.1.1-alpha+1699813812660
 
 flutter:
-    fonts:
-      - family: Local Roboto
-        fonts:
-          - asset: lib/assets/fonts/Roboto-Thin.ttf
-            weight: 100
-          - asset: lib/assets/fonts/Roboto-ThinItalic.ttf
-            weight: 100
-            style: italic
-          - asset: lib/assets/fonts/Roboto-ExtraLight.ttf
-            weight: 200
-          - asset: lib/assets/fonts/Roboto-ExtraLightItalic.ttf
-            weight: 200
-            style: italic
-          - asset: lib/assets/fonts/Roboto-Light.ttf
-            weight: 300
-          - asset: lib/assets/fonts/Roboto-LightItalic.ttf
-            weight: 300
-            style: italic
-          - asset: lib/assets/fonts/Roboto-Regular.ttf
-          - asset: lib/assets/fonts/Roboto-Italic.ttf
-            style: italic
-          - asset: lib/assets/fonts/Roboto-Medium.ttf
-            weight: 500
-          - asset: lib/assets/fonts/Roboto-MediumItalic.ttf
-            weight: 500
-            style: italic
-          - asset: lib/assets/fonts/Roboto-SemiBold.ttf
-            weight: 600
-          - asset: lib/assets/fonts/Roboto-SemiBoldItalic.ttf
-            weight: 600
-            style: italic
-          - asset: lib/assets/fonts/Roboto-Bold.ttf
-            weight: 700
-          - asset: lib/assets/fonts/Roboto-BoldItalic.ttf
-            weight: 700
-            style: italic
-          - asset: lib/assets/fonts/Roboto-ExtraBold.ttf
-            weight: 800
-          - asset: lib/assets/fonts/Roboto-ExtraBoldItalic.ttf
-            weight: 800
-            style: italic
-          - asset: lib/assets/fonts/Roboto-Black.ttf
-            weight: 900
-          - asset: lib/assets/fonts/Roboto-BlackItalic.ttf
-            weight: 900
-            style: italic
+  # Required due to the usage of bison_design_system.
+  uses-material-design: true
+
+  fonts:
+    - family: Local Roboto
+      fonts:
+        - asset: lib/assets/fonts/Roboto-Thin.ttf
+          weight: 100
+        - asset: lib/assets/fonts/Roboto-ThinItalic.ttf
+          weight: 100
+          style: italic
+        - asset: lib/assets/fonts/Roboto-ExtraLight.ttf
+          weight: 200
+        - asset: lib/assets/fonts/Roboto-ExtraLightItalic.ttf
+          weight: 200
+          style: italic
+        - asset: lib/assets/fonts/Roboto-Light.ttf
+          weight: 300
+        - asset: lib/assets/fonts/Roboto-LightItalic.ttf
+          weight: 300
+          style: italic
+        - asset: lib/assets/fonts/Roboto-Regular.ttf
+        - asset: lib/assets/fonts/Roboto-Italic.ttf
+          style: italic
+        - asset: lib/assets/fonts/Roboto-Medium.ttf
+          weight: 500
+        - asset: lib/assets/fonts/Roboto-MediumItalic.ttf
+          weight: 500
+          style: italic
+        - asset: lib/assets/fonts/Roboto-SemiBold.ttf
+          weight: 600
+        - asset: lib/assets/fonts/Roboto-SemiBoldItalic.ttf
+          weight: 600
+          style: italic
+        - asset: lib/assets/fonts/Roboto-Bold.ttf
+          weight: 700
+        - asset: lib/assets/fonts/Roboto-BoldItalic.ttf
+          weight: 700
+          style: italic
+        - asset: lib/assets/fonts/Roboto-ExtraBold.ttf
+          weight: 800
+        - asset: lib/assets/fonts/Roboto-ExtraBoldItalic.ttf
+          weight: 800
+          style: italic
+        - asset: lib/assets/fonts/Roboto-Black.ttf
+          weight: 900
+        - asset: lib/assets/fonts/Roboto-BlackItalic.ttf
+          weight: 900
+          style: italic

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,12 +21,12 @@ dependencies:
   flutter_controls_auth:
     git:
       url: https://github.com/fermi-ad/flutter-controls-auth.git
-      ref: main
+      ref: deb0eb6bbbaf74a70d637dbcfca5c298d8340119
 
   bison_design_system:
     git:
       url: https://github.com/fermi-ad/flutter-bison-design-system.git
-      ref: main
+      ref: 5ffc3a5eddd792e9c039ed732246982ca350b243
 
 dev_dependencies:
   flutter_test:

--- a/test/unit_tests/otel_tracing_test.dart
+++ b/test/unit_tests/otel_tracing_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_controls_core/flutter_controls_core.dart';
+import 'package:fixnum/fixnum.dart' as fixnum;
+import 'package:opentelemetry/api.dart' as otel;
+import 'package:test/test.dart';
+
+void main() {
+  group('otel_tracing', () {
+    test('appTracer can be swapped for tests and restored', () {
+      final original = appTracer;
+      final fake = _FakeTracer();
+
+      appTracer = fake;
+      expect(identical(appTracer, fake), isTrue);
+
+      // Restore to avoid leaking state across tests.
+      appTracer = original;
+      expect(identical(appTracer, original), isTrue);
+    });
+
+    test('runWithSpan ends span on success', () {
+      final original = appTracer;
+      final fake = _FakeTracer();
+      appTracer = fake;
+
+      final result = appTracer.runWithSpan<int>('op', (span) {
+        expect(span, isA<_FakeSpan>());
+        return 123;
+      });
+
+      expect(result, 123);
+      expect(fake.started, 1);
+      expect(fake.ended, 1);
+
+      appTracer = original;
+    });
+
+    test('runWithSpan ends span even when callback throws', () {
+      final original = appTracer;
+      final fake = _FakeTracer();
+      appTracer = fake;
+
+      expect(
+        () => appTracer.runWithSpan<void>('op', (span) {
+          throw StateError('boom');
+        }),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(fake.started, 1);
+      expect(fake.ended, 1);
+
+      appTracer = original;
+    });
+
+    test('runWithSpanAsync ends span on success', () async {
+      final original = appTracer;
+      final fake = _FakeTracer();
+      appTracer = fake;
+
+      final result = await appTracer.runWithSpanAsync<String>('op', (
+        span,
+      ) async {
+        return 'ok';
+      });
+
+      expect(result, 'ok');
+      expect(fake.started, 1);
+      expect(fake.ended, 1);
+
+      appTracer = original;
+    });
+
+    test('runWithSpanAsync ends span even when callback throws', () async {
+      final original = appTracer;
+      final fake = _FakeTracer();
+      appTracer = fake;
+
+      await expectLater(
+        () => appTracer.runWithSpanAsync<void>('op', (span) async {
+          throw ArgumentError('boom');
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(fake.started, 1);
+      expect(fake.ended, 1);
+
+      appTracer = original;
+    });
+  });
+}
+
+final class _FakeTracer implements AppTracer {
+  int started = 0;
+  int ended = 0;
+
+  @override
+  otel.Span startSpan(String name, {Map<String, Object?>? attributes}) {
+    started++;
+    return _FakeSpan();
+  }
+
+  @override
+  void addEvent(
+    otel.Span span,
+    String name, {
+    Map<String, Object?>? attributes,
+  }) {
+    // No-op for this Dart-only suite.
+  }
+
+  @override
+  void endSpan(otel.Span span) {
+    ended++;
+  }
+
+  @override
+  R runWithSpan<R>(
+    String name,
+    R Function(otel.Span span) fn, {
+    Map<String, Object?>? attributes,
+  }) {
+    final span = startSpan(name, attributes: attributes);
+    try {
+      return fn(span);
+    } finally {
+      endSpan(span);
+    }
+  }
+
+  @override
+  Future<R> runWithSpanAsync<R>(
+    String name,
+    Future<R> Function(otel.Span span) fn, {
+    Map<String, Object?>? attributes,
+  }) async {
+    final span = startSpan(name, attributes: attributes);
+    try {
+      return await fn(span);
+    } finally {
+      endSpan(span);
+    }
+  }
+}
+
+/// Minimal fake span for tests.
+///
+/// The OpenTelemetry Dart API uses an abstract `Span` with a fairly large
+/// surface area. We only need it to be a concrete type.
+final class _FakeSpan implements otel.Span {
+  @override
+  void addEvent(
+    String name, {
+    List<otel.Attribute> attributes = const [],
+    fixnum.Int64? timestamp,
+  }) {}
+
+  @override
+  void end({fixnum.Int64 endTime = fixnum.Int64.ZERO}) {}
+
+  bool get isRecording => false;
+
+  @override
+  otel.SpanContext get spanContext => otel.SpanContext.invalid();
+
+  @override
+  otel.SpanId get parentSpanId => otel.SpanId.invalid();
+
+  @override
+  void recordException(
+    exception, {
+    List<otel.Attribute> attributes = const [],
+    bool escaped = false,
+    StackTrace stackTrace = StackTrace.empty,
+  }) {}
+
+  @override
+  void setAttribute(otel.Attribute attribute) {}
+
+  @override
+  void setAttributes(List<otel.Attribute> attributes) {}
+
+  @override
+  void setName(String name) {}
+
+  @override
+  void setStatus(otel.StatusCode status, [String description = '']) {}
+
+  void updateName(String name) {}
+}

--- a/test/unit_tests/otel_tracing_test.dart
+++ b/test/unit_tests/otel_tracing_test.dart
@@ -1,190 +1,57 @@
-import 'package:flutter_controls_core/flutter_controls_core.dart';
-import 'package:fixnum/fixnum.dart' as fixnum;
-import 'package:opentelemetry/api.dart' as otel;
+import 'package:flutter_controls_core/flutter_controls_core.dart'
+    show appTracer;
+import 'package:flutter_controls_core/src/otel_tracing.dart'
+    show initOpenTelemetry;
+import 'package:opentelemetry/sdk.dart' show SpanExporter;
 import 'package:test/test.dart';
 
 void main() {
-  group('otel_tracing', () {
-    test('appTracer can be swapped for tests and restored', () {
-      final original = appTracer;
-      final fake = _FakeTracer();
-
-      appTracer = fake;
-      expect(identical(appTracer, fake), isTrue);
-
-      // Restore to avoid leaking state across tests.
-      appTracer = original;
-      expect(identical(appTracer, original), isTrue);
+  group('otel_tracing (default tracer)', () {
+    setUpAll(() async {
+      // Ensure the global tracer is initialized for the default appTracer.
+      // Use a no-op exporter so tests don't spam stdout.
+      await initOpenTelemetry(exporter: _NoopSpanExporter());
     });
 
-    test('runWithSpan ends span on success', () {
-      final original = appTracer;
-      final fake = _FakeTracer();
-      appTracer = fake;
-
-      final result = appTracer.runWithSpan<int>('op', (span) {
-        expect(span, isA<_FakeSpan>());
-        return 123;
-      });
-
+    test('runWithSpan returns callback result', () {
+      final result = appTracer.runWithSpan<int>('op', (_) => 123);
       expect(result, 123);
-      expect(fake.started, 1);
-      expect(fake.ended, 1);
-
-      appTracer = original;
     });
 
     test('runWithSpan ends span even when callback throws', () {
-      final original = appTracer;
-      final fake = _FakeTracer();
-      appTracer = fake;
-
       expect(
-        () => appTracer.runWithSpan<void>('op', (span) {
+        () => appTracer.runWithSpan<void>('op', (_) {
           throw StateError('boom');
         }),
         throwsA(isA<StateError>()),
       );
-
-      expect(fake.started, 1);
-      expect(fake.ended, 1);
-
-      appTracer = original;
     });
 
-    test('runWithSpanAsync ends span on success', () async {
-      final original = appTracer;
-      final fake = _FakeTracer();
-      appTracer = fake;
-
-      final result = await appTracer.runWithSpanAsync<String>('op', (
-        span,
-      ) async {
+    test('runWithSpanAsync returns callback result', () async {
+      final result = await appTracer.runWithSpanAsync<String>('op', (_) async {
         return 'ok';
       });
-
       expect(result, 'ok');
-      expect(fake.started, 1);
-      expect(fake.ended, 1);
-
-      appTracer = original;
     });
 
     test('runWithSpanAsync ends span even when callback throws', () async {
-      final original = appTracer;
-      final fake = _FakeTracer();
-      appTracer = fake;
-
       await expectLater(
-        () => appTracer.runWithSpanAsync<void>('op', (span) async {
+        () => appTracer.runWithSpanAsync<void>('op', (_) async {
           throw ArgumentError('boom');
         }),
         throwsA(isA<ArgumentError>()),
       );
-
-      expect(fake.started, 1);
-      expect(fake.ended, 1);
-
-      appTracer = original;
     });
   });
 }
 
-final class _FakeTracer implements AppTracer {
-  int started = 0;
-  int ended = 0;
+final class _NoopSpanExporter implements SpanExporter {
+  @override
+  Future<void> export(List spans) async {}
 
   @override
-  otel.Span startSpan(String name, {Map<String, Object?>? attributes}) {
-    started++;
-    return _FakeSpan();
-  }
+  Future<void> forceFlush() async {}
 
   @override
-  void addEvent(
-    otel.Span span,
-    String name, {
-    Map<String, Object?>? attributes,
-  }) {
-    // No-op for this Dart-only suite.
-  }
-
-  @override
-  void endSpan(otel.Span span) {
-    ended++;
-  }
-
-  @override
-  R runWithSpan<R>(
-    String name,
-    R Function(otel.Span span) fn, {
-    Map<String, Object?>? attributes,
-  }) {
-    final span = startSpan(name, attributes: attributes);
-    try {
-      return fn(span);
-    } finally {
-      endSpan(span);
-    }
-  }
-
-  @override
-  Future<R> runWithSpanAsync<R>(
-    String name,
-    Future<R> Function(otel.Span span) fn, {
-    Map<String, Object?>? attributes,
-  }) async {
-    final span = startSpan(name, attributes: attributes);
-    try {
-      return await fn(span);
-    } finally {
-      endSpan(span);
-    }
-  }
-}
-
-/// Minimal fake span for tests.
-///
-/// The OpenTelemetry Dart API uses an abstract `Span` with a fairly large
-/// surface area. We only need it to be a concrete type.
-final class _FakeSpan implements otel.Span {
-  @override
-  void addEvent(
-    String name, {
-    List<otel.Attribute> attributes = const [],
-    fixnum.Int64? timestamp,
-  }) {}
-
-  @override
-  void end({fixnum.Int64 endTime = fixnum.Int64.ZERO}) {}
-
-  bool get isRecording => false;
-
-  @override
-  otel.SpanContext get spanContext => otel.SpanContext.invalid();
-
-  @override
-  otel.SpanId get parentSpanId => otel.SpanId.invalid();
-
-  @override
-  void recordException(
-    exception, {
-    List<otel.Attribute> attributes = const [],
-    bool escaped = false,
-    StackTrace stackTrace = StackTrace.empty,
-  }) {}
-
-  @override
-  void setAttribute(otel.Attribute attribute) {}
-
-  @override
-  void setAttributes(List<otel.Attribute> attributes) {}
-
-  @override
-  void setName(String name) {}
-
-  @override
-  void setStatus(otel.StatusCode status, [String description = '']) {}
-
-  void updateName(String name) {}
+  Future<void> shutdown() async {}
 }

--- a/test/widget/app_scaffold_test.dart
+++ b/test/widget/app_scaffold_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_controls_core/flutter_controls_core.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  group('App scaffolds (smoke)', () {
+    testWidgets('StandardApp builds (no auth)', (tester) async {
+      await tester.pumpWidget(
+        StandardApp<ChangeNotifier?>(
+          title: 'Test App',
+          body: const Center(child: Text('Hello')),
+        ),
+      );
+
+      expect(find.text('Hello'), findsOneWidget);
+    });
+
+    testWidgets('NonAuthRouterApp builds', (tester) async {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const Scaffold(body: Center(child: Text('Home'))),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NonAuthRouterApp(title: 'Router App', router: router),
+        ),
+      );
+
+      // Let router settle.
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsOneWidget);
+    });
+  });
+}

--- a/test/widget/app_scaffold_test.dart
+++ b/test/widget/app_scaffold_test.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_controls_core/flutter_controls_core.dart';
-import 'package:go_router/go_router.dart';
+import 'package:flutter_controls_core/flutter_controls_core.dart'
+    show NonAuthRouterApp, StandardApp;
+import 'package:go_router/go_router.dart' show GoRoute, GoRouter;
 
 void main() {
   group('App scaffolds (smoke)', () {

--- a/test/widget/parameter_panel_row_test.dart
+++ b/test/widget/parameter_panel_row_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_controls_core/flutter_controls_core.dart';
+
+void main() {
+  group('ParameterPanelRow (smoke)', () {
+    testWidgets('builds with static value', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ParameterPanelRow(
+              label: 'Temperature',
+              value: '25',
+              units: '°C',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Temperature'), findsOneWidget);
+      expect(find.text('25'), findsOneWidget);
+      expect(find.text('°C'), findsOneWidget);
+    });
+
+    testWidgets('builds with valueBuilder', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ParameterPanelRow(
+              label: 'Pressure',
+              valueBuilder: (_) => '101.3',
+              units: 'kPa',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Pressure'), findsOneWidget);
+      expect(find.text('101.3'), findsOneWidget);
+      expect(find.text('kPa'), findsOneWidget);
+    });
+
+    testWidgets('builds in editable mode (onValueChanged provided)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ParameterPanelRow(
+              label: 'Setpoint',
+              value: '10',
+              units: 'A',
+              onValueChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Setpoint'), findsOneWidget);
+      expect(find.text('10'), findsOneWidget);
+      expect(find.text('A'), findsOneWidget);
+    });
+  });
+}

--- a/test/widget/parameter_panel_row_test.dart
+++ b/test/widget/parameter_panel_row_test.dart
@@ -12,7 +12,7 @@ void main() {
             body: ParameterPanelRow(
               label: 'Temperature',
               value: '25',
-              units: '°C',
+              units: 'C',
             ),
           ),
         ),
@@ -20,7 +20,7 @@ void main() {
 
       expect(find.text('Temperature'), findsOneWidget);
       expect(find.text('25'), findsOneWidget);
-      expect(find.text('°C'), findsOneWidget);
+      expect(find.text('C'), findsOneWidget);
     });
 
     testWidgets('builds with valueBuilder', (tester) async {

--- a/test/widget/parameter_panel_row_test.dart
+++ b/test/widget/parameter_panel_row_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_controls_core/flutter_controls_core.dart';
+import 'package:flutter_controls_core/flutter_controls_core.dart'
+  show ParameterPanelRow;
 
 void main() {
   group('ParameterPanelRow (smoke)', () {

--- a/test/widget/parameter_panel_test.dart
+++ b/test/widget/parameter_panel_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_controls_core/flutter_controls_core.dart';
+import 'package:flutter_controls_core/flutter_controls_core.dart'
+    show ParameterPanel;
 
 void main() {
   group('ParameterPanel (smoke)', () {

--- a/test/widget/parameter_panel_test.dart
+++ b/test/widget/parameter_panel_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_controls_core/flutter_controls_core.dart';
+
+void main() {
+  group('ParameterPanel (smoke)', () {
+    testWidgets('builds with title and contents', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ParameterPanel(
+              title: 'Device Status',
+              contents: [
+                Text('Temperature: 25°C'),
+                Text('Pressure: 101.3 kPa'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Device Status'), findsOneWidget);
+      expect(find.text('Temperature: 25°C'), findsOneWidget);
+      expect(find.text('Pressure: 101.3 kPa'), findsOneWidget);
+    });
+  });
+}

--- a/test/widget/parameter_panel_test.dart
+++ b/test/widget/parameter_panel_test.dart
@@ -12,7 +12,7 @@ void main() {
             body: ParameterPanel(
               title: 'Device Status',
               contents: [
-                Text('Temperature: 25°C'),
+                Text('Temperature: 25 C'),
                 Text('Pressure: 101.3 kPa'),
               ],
             ),
@@ -21,7 +21,7 @@ void main() {
       );
 
       expect(find.text('Device Status'), findsOneWidget);
-      expect(find.text('Temperature: 25°C'), findsOneWidget);
+      expect(find.text('Temperature: 25 C'), findsOneWidget);
       expect(find.text('Pressure: 101.3 kPa'), findsOneWidget);
     });
   });


### PR DESCRIPTION
Closes https://github.com/fermi-ad/flutter-controls-core/issues/102

- Adds our standard GitHub Flutter integration workflow
- Adds some basic unit and widget tests (not enough for high coverage)
- Pins the GitHub-sourced pubspec.yaml dependencies (flutter_controls_auth and bison_design_system) to specific commits
- Bumps the min Flutter version to match the min Dart version
- Small formatting changes
- Moves a doc comment to top of its file